### PR TITLE
fix(apps): align csgclaw latest version with GitHub-style release JSON

### DIFF
--- a/internal/apps/manager.go
+++ b/internal/apps/manager.go
@@ -240,7 +240,7 @@ func appSpecs() []appSpec {
 			latest: &latestVersionSource{
 				baseURL: "https://csgclaw.opencsg.com/releases/latest",
 				envVar:  "CSGHUB_LITE_CSGCLAW_LATEST_URL",
-				format:  "version-json",
+				format:  "github-release",
 			},
 			unix: &scriptSource{
 				mirrorURL:    "https://csgclaw.opencsg.com/install.sh",

--- a/internal/apps/manager_test.go
+++ b/internal/apps/manager_test.go
@@ -275,8 +275,9 @@ func TestAppUpdateAvailableComparesVersionOrder(t *testing.T) {
 
 func TestFetchLatestVersionParsesGitHubReleaseTag(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/OpenCSGs/csgclaw/releases/latest" {
-			t.Fatalf("latest path = %q, want /repos/OpenCSGs/csgclaw/releases/latest", r.URL.Path)
+		// Mirrors https://csgclaw.opencsg.com/releases/latest (GitHub-compatible JSON).
+		if r.URL.Path != "/releases/latest" {
+			t.Fatalf("latest path = %q, want /releases/latest", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"tag_name":"v0.2.8"}`))
@@ -287,7 +288,7 @@ func TestFetchLatestVersionParsesGitHubReleaseTag(t *testing.T) {
 	latest, err := mgr.fetchLatestVersion(context.Background(), appSpec{
 		id: "csgclaw",
 		latest: &latestVersionSource{
-			baseURL: server.URL + "/repos/OpenCSGs/csgclaw/releases/latest",
+			baseURL: server.URL + "/releases/latest",
 			format:  "github-release",
 		},
 	})

--- a/internal/apps/scripts/csgclaw-install.sh
+++ b/internal/apps/scripts/csgclaw-install.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 APP="${APP:-csgclaw}"
-REPO="${REPO:-OpenCSGs/csgclaw}"
 VERSION="${VERSION:-${1:-latest}}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 LIB_DIR="${LIB_DIR:-$HOME/.local/lib/${APP}}"
@@ -66,8 +65,11 @@ ensure_supported_platform() {
 }
 
 resolve_latest_version() {
-  local api_url tag
-  api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  local api_url tag base
+  # Mirror serves GitHub-compatible JSON at ${BASE_URL}/latest (tag_name, assets, ...).
+  base="${BASE_URL:-https://csgclaw.opencsg.com/releases}"
+  while [[ "$base" == */ ]]; do base="${base%/}"; done
+  api_url="${base}/latest"
   tag="$(curl -fsSL "$api_url" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
   if [[ -z "$tag" ]]; then
     log "ERROR: failed to resolve latest release from ${api_url}"


### PR DESCRIPTION
- Use github-release format for csgclaw.opencsg.com/releases/latest (tag_name)
- Resolve latest tag in csgclaw-install.sh from mirror /releases/latest
- Update manager test for mirror URL path