### PR TITLE
feat: add model alias support for Anthropic protocol compatibility

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -28,6 +29,31 @@ func (c *Config) StorageDir() string {
 	return StorageDir(c.ModelDir, c.DatasetDir)
 }
 
+// ResolveModelAlias resolves a model alias to the actual model name.
+// If the modelID is not an alias, it returns the modelID unchanged.
+func (c *Config) ResolveModelAlias(modelID string) string {
+	modelID = strings.TrimSpace(modelID)
+	if c.ModelAliases == nil {
+		return modelID
+	}
+	if resolved, ok := c.ModelAliases[modelID]; ok {
+		return strings.TrimSpace(resolved)
+	}
+	return modelID
+}
+
+// GetAllAliases returns all configured model aliases.
+func (c *Config) GetAllAliases() map[string]string {
+	if c.ModelAliases == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(c.ModelAliases))
+	for k, v := range c.ModelAliases {
+		out[k] = v
+	}
+	return out
+}
+
 type Config struct {
 	ServerURL            string            `json:"server_url"`
 	AIGatewayURL         string            `json:"ai_gateway_url,omitempty"`
@@ -37,6 +63,7 @@ type Config struct {
 	DatasetDir           string            `json:"dataset_dir"`
 	AIAppPreferredModels map[string]string `json:"ai_app_preferred_models,omitempty"`
 	WebSearch            WebSearchConfig   `json:"web_search,omitempty"`
+	ModelAliases         map[string]string `json:"model_aliases,omitempty"` // alias -> actual_model
 }
 
 type WebSearchConfig struct {
@@ -187,6 +214,9 @@ func Load() (*Config, error) {
 			globalConfig.AIAppPreferredModels = map[string]string{}
 		}
 		globalConfig.WebSearch = NormalizeWebSearchConfig(globalConfig.WebSearch)
+		if globalConfig.ModelAliases == nil {
+			globalConfig.ModelAliases = map[string]string{}
+		}
 	})
 	return globalConfig, loadErr
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,3 +162,88 @@ func TestStorageSubdirsForRoot(t *testing.T) {
 		t.Fatalf("DatasetDirForStorage(%q) = %q", root, got)
 	}
 }
+
+func TestResolveModelAlias(t *testing.T) {
+	tests := []struct {
+		name      string
+		aliases   map[string]string
+		modelID   string
+		wantModel string
+	}{
+		{
+			name:      "no aliases configured",
+			aliases:   nil,
+			modelID:   "claude-sonnet-4",
+			wantModel: "claude-sonnet-4",
+		},
+		{
+			name:      "alias exists",
+			aliases:   map[string]string{"claude-sonnet-4": "deepseek-chat"},
+			modelID:   "claude-sonnet-4",
+			wantModel: "deepseek-chat",
+		},
+		{
+			name:      "alias does not exist",
+			aliases:   map[string]string{"claude-sonnet-4": "deepseek-chat"},
+			modelID:   "other-model",
+			wantModel: "other-model",
+		},
+		{
+			name:      "alias with whitespace in modelID",
+			aliases:   map[string]string{"claude-sonnet-4": "deepseek-chat"},
+			modelID:   "  claude-sonnet-4  ",
+			wantModel: "deepseek-chat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{ModelAliases: tt.aliases}
+			got := cfg.ResolveModelAlias(tt.modelID)
+			if got != tt.wantModel {
+				t.Errorf("ResolveModelAlias(%q) = %q, want %q", tt.modelID, got, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestGetAllAliases(t *testing.T) {
+	tests := []struct {
+		name    string
+		aliases map[string]string
+		wantLen int
+	}{
+		{
+			name:    "nil aliases",
+			aliases: nil,
+			wantLen: 0,
+		},
+		{
+			name:    "empty aliases",
+			aliases: map[string]string{},
+			wantLen: 0,
+		},
+		{
+			name:    "multiple aliases",
+			aliases: map[string]string{"claude-sonnet-4": "deepseek-chat", "claude-opus-4": "gpt-4o"},
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{ModelAliases: tt.aliases}
+			got := cfg.GetAllAliases()
+			if len(got) != tt.wantLen {
+				t.Errorf("GetAllAliases() returned %d aliases, want %d", len(got), tt.wantLen)
+			}
+			// Verify it returns a copy, not the original
+			if tt.aliases != nil && len(tt.aliases) > 0 {
+				got["new-alias"] = "new-model"
+				if _, exists := tt.aliases["new-alias"]; exists {
+					t.Error("GetAllAliases() did not return a copy, modifying it affected the original")
+				}
+			}
+		})
+	}
+}

--- a/internal/inference/openai.go
+++ b/internal/inference/openai.go
@@ -59,6 +59,11 @@ func (e *openAIEngine) chatCompletionsEndpoint() string {
 }
 
 func (e *openAIEngine) ChatCompletion(ctx context.Context, reqBody map[string]interface{}) (*http.Response, error) {
+	// Ensure model field uses the engine's actual model name
+	if reqBody == nil {
+		reqBody = map[string]interface{}{}
+	}
+	reqBody["model"] = e.modelName
 	reqBody = sanitizeOpenAIRequestBody(e.modelName, reqBody)
 	body, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/server/cloud_models.go
+++ b/internal/server/cloud_models.go
@@ -71,6 +71,27 @@ func (s *Server) listAvailableModelsWithRefresh(ctx context.Context, refreshClou
 		out = append(out, item)
 	}
 
+	// Add alias models
+	aliases := s.cfg.GetAllAliases()
+	for alias, actualModel := range aliases {
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		// Find the actual model info to copy its properties
+		for _, item := range out {
+			if strings.TrimSpace(item.Model) == actualModel {
+				aliasInfo := item
+				aliasInfo.Name = alias
+				aliasInfo.Model = alias
+				aliasInfo.Label = alias
+				aliasInfo.DisplayName = alias + " (alias → " + actualModel + ")"
+				seen[alias] = struct{}{}
+				out = append(out, aliasInfo)
+				break
+			}
+		}
+	}
+
 	sortModelsByPriority(out)
 
 	return out, nil

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -112,6 +112,8 @@ func (s *Server) cloudAuthStatus(ctx context.Context) cloudAuthStatus {
 }
 
 func (s *Server) getChatEngine(ctx context.Context, modelID, source string, numCtx, numParallel, nGPULayers int, cacheTypeK, cacheTypeV, dtype string) (inference.Engine, error) {
+	// Resolve model alias first
+	modelID = s.cfg.ResolveModelAlias(modelID)
 	source = strings.TrimSpace(source)
 	normalizedSource := strings.ToLower(source)
 	if providerIDFromSource(source) != "" {


### PR DESCRIPTION
Add model alias functionality to allow Claude Desktop and other clients that only support Anthropic model names to use third-party models through csghub-lite proxy.

Changes:
- Add ModelAliases field to config structure
- Add ResolveModelAlias and GetAllAliases methods
- Apply alias resolution in getChatEngine before model lookup
- Include alias models in /v1/models and /api/tags responses
- Fix OpenAI engine to use actual model name in request body

Users can configure aliases in ~/.csghub-lite/config.json: {
  "model_aliases": {
    "claude-opus-4-7": "glm-5(infini-ai)"
  }
}

Generated with AI