### PR TITLE
Fix Windows embedding runtime self-heal

### DIFF
--- a/internal/config/logs.go
+++ b/internal/config/logs.go
@@ -7,9 +7,11 @@ import (
 )
 
 const (
-	LogsDir                = "logs"
-	ServerLogFileName      = "csghub-lite.log"
-	LlamaServerLogFileName = "llama-server.log"
+	LogsDir                    = "logs"
+	ServerLogFileName          = "csghub-lite.log"
+	LlamaServerLogFileName     = "llama-server.log"
+	EmbeddingWorkerLogFileName = "embedding-worker.log"
+	DiffusersWorkerLogFileName = "diffusers-worker.log"
 
 	LogStderrEnv          = "CSGHUB_LITE_LOG_STDERR"
 	DisableFileLoggingEnv = "CSGHUB_LITE_DISABLE_FILE_LOGGING"
@@ -29,6 +31,14 @@ func ServerLogPath() (string, error) {
 
 func LlamaServerLogPath() (string, error) {
 	return logPath(LlamaServerLogFileName)
+}
+
+func EmbeddingWorkerLogPath() (string, error) {
+	return logPath(EmbeddingWorkerLogFileName)
+}
+
+func DiffusersWorkerLogPath() (string, error) {
+	return logPath(DiffusersWorkerLogFileName)
 }
 
 func LogStderrEnabled() bool {

--- a/internal/config/logs_test.go
+++ b/internal/config/logs_test.go
@@ -34,4 +34,20 @@ func TestLogPaths(t *testing.T) {
 	if want := filepath.Join(logDir, LlamaServerLogFileName); llamaLogPath != want {
 		t.Fatalf("LlamaServerLogPath() = %q, want %q", llamaLogPath, want)
 	}
+
+	embeddingLogPath, err := EmbeddingWorkerLogPath()
+	if err != nil {
+		t.Fatalf("EmbeddingWorkerLogPath() error: %v", err)
+	}
+	if want := filepath.Join(logDir, EmbeddingWorkerLogFileName); embeddingLogPath != want {
+		t.Fatalf("EmbeddingWorkerLogPath() = %q, want %q", embeddingLogPath, want)
+	}
+
+	diffusersLogPath, err := DiffusersWorkerLogPath()
+	if err != nil {
+		t.Fatalf("DiffusersWorkerLogPath() error: %v", err)
+	}
+	if want := filepath.Join(logDir, DiffusersWorkerLogFileName); diffusersLogPath != want {
+		t.Fatalf("DiffusersWorkerLogPath() = %q, want %q", diffusersLogPath, want)
+	}
 }

--- a/internal/embedding/worker.go
+++ b/internal/embedding/worker.go
@@ -7,17 +7,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/opencsgs/csglite/internal/config"
 	"github.com/opencsgs/csglite/internal/imagegen"
 	"github.com/opencsgs/csglite/internal/inference"
+	"github.com/opencsgs/csglite/internal/logutil"
 )
 
 //go:embed worker/embedding_worker.py
@@ -31,6 +34,8 @@ type PythonEngine struct {
 	exitCh    chan error
 	port      int
 	client    *http.Client
+	logBuf    *logutil.TailWriter
+	logFile   *os.File
 }
 
 func NewPythonEngine(ctx context.Context, modelName, modelDir string, runtimeManager *imagegen.RuntimeManager) (*PythonEngine, error) {
@@ -59,9 +64,27 @@ func NewPythonEngine(ctx context.Context, modelName, modelDir string, runtimeMan
 	storageRoot := storageRootFromModelDir(modelDir)
 	cmd := exec.Command(runtimeManager.PythonPath(), workerPath, "--model-dir", modelDir, "--model-name", modelName, "--port", strconv.Itoa(port), "--storage-root", storageRoot, "--temp-dir", tempDir)
 	cmd.Env = withTempDir(os.Environ(), tempDir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	logBuf := logutil.NewTailWriter(64 * 1024)
+	stdout := io.Writer(logBuf)
+	stderr := io.Writer(logBuf)
+	var logFile *os.File
+	if config.FileLoggingEnabled() {
+		if path, err := config.EmbeddingWorkerLogPath(); err != nil {
+			log.Printf("warning: could not resolve embedding worker log path: %v", err)
+		} else if file, err := logutil.OpenAppendFile(path); err != nil {
+			log.Printf("warning: could not open embedding worker log file %s: %v", path, err)
+		} else {
+			logFile = file
+			stdout = io.MultiWriter(stdout, file)
+			stderr = io.MultiWriter(stderr, file)
+		}
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
 		return nil, fmt.Errorf("starting embedding worker: %w", err)
 	}
 	exitCh := make(chan error, 1)
@@ -77,6 +100,8 @@ func NewPythonEngine(ctx context.Context, modelName, modelDir string, runtimeMan
 		exitCh:    exitCh,
 		port:      port,
 		client:    &http.Client{Timeout: 30 * time.Minute},
+		logBuf:    logBuf,
+		logFile:   logFile,
 	}
 	if err := engine.waitReady(ctx); err != nil {
 		_ = engine.Close()
@@ -127,6 +152,10 @@ func (e *PythonEngine) Close() error {
 		case <-time.After(5 * time.Second):
 		}
 	}
+	if e.logFile != nil {
+		_ = e.logFile.Close()
+		e.logFile = nil
+	}
 	return nil
 }
 
@@ -142,9 +171,9 @@ func (e *PythonEngine) waitReady(ctx context.Context) error {
 			return ctx.Err()
 		case err := <-e.exitCh:
 			if err != nil {
-				return fmt.Errorf("embedding worker exited before becoming ready: %w", err)
+				return fmt.Errorf("%s", e.workerStartError("embedding worker exited before becoming ready: "+err.Error()))
 			}
-			return fmt.Errorf("embedding worker exited before becoming ready")
+			return fmt.Errorf("%s", e.workerStartError("embedding worker exited before becoming ready"))
 		default:
 		}
 		resp, err := e.client.Get(e.url("/health"))
@@ -156,11 +185,20 @@ func (e *PythonEngine) waitReady(ctx context.Context) error {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	return fmt.Errorf("timeout waiting for embedding worker")
+	return fmt.Errorf("%s", e.workerStartError("timeout waiting for embedding worker"))
 }
 
 func (e *PythonEngine) url(path string) string {
 	return fmt.Sprintf("http://127.0.0.1:%d%s", e.port, path)
+}
+
+func (e *PythonEngine) workerStartError(msg string) string {
+	if e.logBuf != nil {
+		if tail := strings.TrimSpace(e.logBuf.String()); tail != "" {
+			msg += "\n\nembedding worker output:\n" + tail
+		}
+	}
+	return msg
 }
 
 func writeEmbeddingWorkerScript(runtimeDir string) error {

--- a/internal/embedding/worker_test.go
+++ b/internal/embedding/worker_test.go
@@ -1,0 +1,40 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opencsgs/csglite/internal/logutil"
+)
+
+func TestWaitReadyIncludesWorkerOutputTail(t *testing.T) {
+	logBuf := logutil.NewTailWriter(64 * 1024)
+	if _, err := logBuf.Write([]byte("Traceback: libtorchaudio.pyd failed to load")); err != nil {
+		t.Fatal(err)
+	}
+	exitCh := make(chan error, 1)
+	exitCh <- errors.New("exit status 1")
+	close(exitCh)
+
+	engine := &PythonEngine{
+		exitCh: exitCh,
+		port:   1,
+		client: &http.Client{Timeout: time.Millisecond},
+		logBuf: logBuf,
+	}
+	err := engine.waitReady(context.Background())
+	if err == nil {
+		t.Fatal("waitReady returned nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "embedding worker exited before becoming ready") {
+		t.Fatalf("waitReady error missing exit context: %q", msg)
+	}
+	if !strings.Contains(msg, "Traceback: libtorchaudio.pyd failed to load") {
+		t.Fatalf("waitReady error missing worker output tail: %q", msg)
+	}
+}

--- a/internal/imagegen/runtime.go
+++ b/internal/imagegen/runtime.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,6 +95,17 @@ var torchPackages = []string{
 	"torch",
 	"torchvision",
 	"torchaudio",
+}
+
+func embeddingTorchPackages() []string {
+	return embeddingTorchPackagesForGOOS(runtime.GOOS)
+}
+
+func embeddingTorchPackagesForGOOS(goos string) []string {
+	if goos == "windows" {
+		return []string{"torch", "torchvision"}
+	}
+	return torchPackages
 }
 
 // HardwareKind describes the PyTorch wheel/runtime family to use.
@@ -341,6 +353,13 @@ func (m *RuntimeManager) EmbeddingStatus(ctx context.Context) RuntimeStatus {
 	status.Ready = len(missing) == 0
 	if !status.Ready {
 		status.Error = "Embedding runtime is missing Python packages"
+		return status
+	}
+	if runtime.GOOS == "windows" {
+		if err := verifyImports(ctx, status.Python, []string{"torch", "transformers"}); err != nil {
+			status.Ready = false
+			status.Error = windowsEmbeddingImportError(err)
+		}
 	}
 	return status
 }
@@ -604,8 +623,13 @@ func (m *RuntimeManager) InstallEmbeddingWithProgressOptions(ctx context.Context
 		} else {
 			progress("install PyTorch", 4, 5)
 		}
-		if err := m.uvPipInstall(ctx, python, indexes, torchPackages, upgradePackages, true); err != nil {
+		if err := m.uvPipInstall(ctx, python, indexes, embeddingTorchPackages(), upgradePackages, true); err != nil {
 			return m.EmbeddingStatus(ctx), fmt.Errorf("installing PyTorch: %w", err)
+		}
+	}
+	if runtime.GOOS == "windows" {
+		if err := m.uninstallBrokenWindowsTorchaudio(ctx, python, indexes); err != nil {
+			return m.EmbeddingStatus(ctx), err
 		}
 	}
 
@@ -650,7 +674,7 @@ func (m *RuntimeManager) InstallEmbeddingWithProgressOptions(ctx context.Context
 		UpdatedAt:   now,
 		TorchIndex:  torchSourceURL(indexes),
 		PyPIIndex:   indexes.PyPIIndexURL,
-		PackageSpec: append(torchPackages, embeddingPythonPackages...),
+		PackageSpec: append(embeddingTorchPackages(), embeddingPythonPackages...),
 	}
 	if err := writeManifest(filepath.Join(m.rootDir, manifestFileName), manifest); err != nil {
 		return m.EmbeddingStatus(ctx), err
@@ -772,7 +796,7 @@ func (m *RuntimeManager) EmbeddingInstallCommand(hw HardwareKind) []string {
 		cmd = append(cmd, "-i", indexes.PyPIIndexURL)
 	}
 	cmd = append(cmd, "&&", uvPath, "pip", "install", "--python", pythonPath)
-	cmd = append(cmd, torchPackageSpecs(hw, indexes)...)
+	cmd = append(cmd, embeddingTorchPackages()...)
 	cmd = append(cmd, torchInstallIndexArgs(indexes)...)
 	cmd = append(cmd, "&&", uvPath, "pip", "install", "--python", pythonPath)
 	cmd = append(cmd, embeddingPythonPackages...)
@@ -899,19 +923,73 @@ func isChinaLocale() bool {
 }
 
 func findHostPython() (string, error) {
-	candidates := []string{"python3", "python"}
 	if runtime.GOOS == "windows" {
-		candidates = []string{"py", "python"}
+		return findWindowsHostPython()
 	}
+	candidates := []string{"python3", "python"}
 	for _, candidate := range candidates {
 		if path, err := exec.LookPath(candidate); err == nil {
-			if runtime.GOOS == "windows" && candidate == "py" {
-				return path, nil
-			}
+			log.Printf("PYTHON: selected host interpreter path=%s", path)
 			return path, nil
 		}
 	}
-	return "", errors.New("Python 3.10 or 3.11 is required to install the Diffusers runtime")
+	return "", errors.New("Python 3.10, 3.11, or 3.12 is required to install the Diffusers runtime")
+}
+
+func findWindowsHostPython() (string, error) {
+	candidates := []struct {
+		name string
+		args []string
+	}{
+		{name: "py", args: []string{"-3.12"}},
+		{name: "py", args: []string{"-3.11"}},
+		{name: "py", args: []string{"-3.10"}},
+		{name: "python"},
+	}
+	var detectedVersion string
+	for _, candidate := range candidates {
+		if _, err := exec.LookPath(candidate.name); err != nil {
+			continue
+		}
+		path, version, err := probePython(candidate.name, candidate.args...)
+		if err != nil {
+			continue
+		}
+		if detectedVersion == "" {
+			detectedVersion = version
+		}
+		if windowsPythonVersionSupported(version) {
+			log.Printf("PYTHON: selected host interpreter path=%s version=%s", path, version)
+			return path, nil
+		}
+	}
+	if detectedVersion != "" {
+		return "", fmt.Errorf("检测到 Python %s，其 Windows wheel 生态尚不完整，请安装 Python 3.10-3.12", detectedVersion)
+	}
+	return "", errors.New("Python 3.10, 3.11, or 3.12 is required to install the Diffusers runtime")
+}
+
+func probePython(name string, args ...string) (string, string, error) {
+	script := "import sys\nprint(sys.executable)\nprint(f'{sys.version_info[0]}.{sys.version_info[1]}')\n"
+	cmdArgs := append(append([]string{}, args...), "-c", script)
+	out, err := exec.Command(name, cmdArgs...).Output()
+	if err != nil {
+		return "", "", err
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return "", "", fmt.Errorf("unexpected Python probe output: %q", strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(lines[0]), strings.TrimSpace(lines[1]), nil
+}
+
+func windowsPythonVersionSupported(version string) bool {
+	switch version {
+	case "3.10", "3.11", "3.12":
+		return true
+	default:
+		return false
+	}
 }
 
 func missingPackages(ctx context.Context, python string, packages []string) ([]string, error) {
@@ -930,6 +1008,49 @@ print(json.dumps(missing))
 		return nil, fmt.Errorf("decoding runtime package check: %w", err)
 	}
 	return missing, nil
+}
+
+func verifyImports(ctx context.Context, python string, modules []string) error {
+	script := "import importlib, sys\nfor n in sys.argv[1:]:\n    importlib.import_module(n)\n"
+	cmd := exec.CommandContext(ctx, python, append([]string{"-c", script}, modules...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		tail := string(out)
+		if len(tail) > 2048 {
+			tail = tail[len(tail)-2048:]
+		}
+		return fmt.Errorf("python import check failed: %s", strings.TrimSpace(tail))
+	}
+	return nil
+}
+
+func windowsEmbeddingImportError(err error) string {
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	if strings.Contains(msg, "WinError 126") || strings.Contains(lower, "libtorchaudio") {
+		msg += "\n提示: Windows 上检测到 torchaudio 动态库加载失败。请安装 Microsoft Visual C++ Redistributable；csghub-lite 会在准备 embedding runtime 时自动移除 torchaudio。\nHint: torchaudio failed to load on Windows. Install the Microsoft Visual C++ Redistributable; csghub-lite will automatically remove torchaudio when preparing the embedding runtime."
+	}
+	return msg
+}
+
+func (m *RuntimeManager) uninstallBrokenWindowsTorchaudio(ctx context.Context, python string, indexes PackageIndexes) error {
+	missing, err := missingPackages(ctx, python, []string{"torchaudio"})
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		return nil
+	}
+	if err := runCommand(ctx, python, "-c", "import torchaudio"); err == nil {
+		return nil
+	}
+	if err := m.ensurePipAndUV(ctx, python, indexes); err != nil {
+		return err
+	}
+	if err := runCommandEnv(ctx, m.uvInstallEnv(), m.uvPath(), "pip", "uninstall", "--python", python, "-y", "torchaudio"); err != nil {
+		return fmt.Errorf("removing broken torchaudio from embedding runtime: %w", err)
+	}
+	return nil
 }
 
 func (m *RuntimeManager) ensurePipAndUV(ctx context.Context, python string, indexes PackageIndexes) error {

--- a/internal/imagegen/runtime_test.go
+++ b/internal/imagegen/runtime_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -230,6 +232,49 @@ func TestEmbeddingRuntimeInstallCommand(t *testing.T) {
 	}
 }
 
+func TestEmbeddingTorchPackagesByOS(t *testing.T) {
+	windowsPackages := embeddingTorchPackagesForGOOS("windows")
+	for _, unwanted := range []string{"torchaudio"} {
+		if hasString(windowsPackages, unwanted) {
+			t.Fatalf("Windows embedding torch packages should not include %q: %#v", unwanted, windowsPackages)
+		}
+	}
+	for _, want := range []string{"torch", "torchvision"} {
+		if !hasString(windowsPackages, want) {
+			t.Fatalf("Windows embedding torch packages missing %q: %#v", want, windowsPackages)
+		}
+	}
+
+	linuxPackages := embeddingTorchPackagesForGOOS("linux")
+	if len(linuxPackages) != len(torchPackages) {
+		t.Fatalf("Linux embedding torch packages = %#v, want %#v", linuxPackages, torchPackages)
+	}
+	for i := range torchPackages {
+		if linuxPackages[i] != torchPackages[i] {
+			t.Fatalf("Linux embedding torch packages = %#v, want %#v", linuxPackages, torchPackages)
+		}
+	}
+}
+
+func TestVerifyImportsWithFakePython(t *testing.T) {
+	ctx := context.Background()
+	if err := verifyImports(ctx, fakePython(t, 0, ""), []string{"torch"}); err != nil {
+		t.Fatalf("verifyImports success returned error: %v", err)
+	}
+
+	err := verifyImports(ctx, fakePython(t, 1, strings.Repeat("x", 2200)+"libtorchaudio.pyd failed"), []string{"torch"})
+	if err == nil {
+		t.Fatal("verifyImports failure returned nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "libtorchaudio.pyd failed") {
+		t.Fatalf("verifyImports error missing output tail: %q", msg)
+	}
+	if len(msg) > len("python import check failed: ")+2048 {
+		t.Fatalf("verifyImports error was not truncated: length=%d", len(msg))
+	}
+}
+
 func TestBaseASRDependenciesExcludeQwenASR(t *testing.T) {
 	for _, pkg := range requiredASRPythonPackages {
 		if pkg == "qwen_asr" {
@@ -321,6 +366,33 @@ func hasTorchVersionPin(value string) bool {
 	return strings.HasPrefix(value, "torch==") ||
 		strings.HasPrefix(value, "torchvision==") ||
 		strings.HasPrefix(value, "torchaudio==")
+}
+
+func fakePython(t *testing.T, exitCode int, output string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "python.cmd")
+		script := "@echo off\r\n"
+		if output != "" {
+			script += "echo " + output + " 1>&2\r\n"
+		}
+		script += "exit /b " + strconv.Itoa(exitCode) + "\r\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	path := filepath.Join(dir, "python")
+	script := "#!/bin/sh\n"
+	if output != "" {
+		script += "printf '%s' '" + output + "' >&2\n"
+	}
+	script += "exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestTorchInstallIndexArgsAliyunCUDA(t *testing.T) {

--- a/internal/imagegen/worker.go
+++ b/internal/imagegen/worker.go
@@ -7,14 +7,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/opencsgs/csglite/internal/config"
+	"github.com/opencsgs/csglite/internal/logutil"
 	"github.com/opencsgs/csglite/pkg/api"
 )
 
@@ -29,6 +33,8 @@ type DiffusersEngine struct {
 	exitCh    chan error
 	port      int
 	client    *http.Client
+	logBuf    *logutil.TailWriter
+	logFile   *os.File
 }
 
 func NewDiffusersEngine(ctx context.Context, modelName, modelDir string, runtimeManager *RuntimeManager) (*DiffusersEngine, error) {
@@ -51,9 +57,27 @@ func NewDiffusersEngine(ctx context.Context, modelName, modelDir string, runtime
 	}
 	workerPath := filepath.Join(runtimeManager.RootDir(), "diffusers_worker.py")
 	cmd := exec.CommandContext(ctx, runtimeManager.PythonPath(), workerPath, "--model-dir", modelDir, "--model-name", modelName, "--port", strconv.Itoa(port))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	logBuf := logutil.NewTailWriter(64 * 1024)
+	stdout := io.Writer(logBuf)
+	stderr := io.Writer(logBuf)
+	var logFile *os.File
+	if config.FileLoggingEnabled() {
+		if path, err := config.DiffusersWorkerLogPath(); err != nil {
+			log.Printf("warning: could not resolve Diffusers worker log path: %v", err)
+		} else if file, err := logutil.OpenAppendFile(path); err != nil {
+			log.Printf("warning: could not open Diffusers worker log file %s: %v", path, err)
+		} else {
+			logFile = file
+			stdout = io.MultiWriter(stdout, file)
+			stderr = io.MultiWriter(stderr, file)
+		}
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
 		return nil, fmt.Errorf("starting Diffusers worker: %w", err)
 	}
 	exitCh := make(chan error, 1)
@@ -69,6 +93,8 @@ func NewDiffusersEngine(ctx context.Context, modelName, modelDir string, runtime
 		exitCh:    exitCh,
 		port:      port,
 		client:    &http.Client{Timeout: 5 * time.Minute},
+		logBuf:    logBuf,
+		logFile:   logFile,
 	}
 	if err := engine.waitReady(ctx); err != nil {
 		_ = engine.Close()
@@ -117,6 +143,10 @@ func (e *DiffusersEngine) Close() error {
 		case <-time.After(5 * time.Second):
 		}
 	}
+	if e.logFile != nil {
+		_ = e.logFile.Close()
+		e.logFile = nil
+	}
 	return nil
 }
 
@@ -132,9 +162,9 @@ func (e *DiffusersEngine) waitReady(ctx context.Context) error {
 			return ctx.Err()
 		case err := <-e.exitCh:
 			if err != nil {
-				return fmt.Errorf("Diffusers worker exited before becoming ready: %w", err)
+				return fmt.Errorf("%s", e.workerStartError("Diffusers worker exited before becoming ready: "+err.Error()))
 			}
-			return fmt.Errorf("Diffusers worker exited before becoming ready")
+			return fmt.Errorf("%s", e.workerStartError("Diffusers worker exited before becoming ready"))
 		default:
 		}
 		resp, err := e.client.Get(e.url("/health"))
@@ -146,11 +176,20 @@ func (e *DiffusersEngine) waitReady(ctx context.Context) error {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	return fmt.Errorf("timeout waiting for Diffusers worker")
+	return fmt.Errorf("%s", e.workerStartError("timeout waiting for Diffusers worker"))
 }
 
 func (e *DiffusersEngine) url(path string) string {
 	return fmt.Sprintf("http://127.0.0.1:%d%s", e.port, path)
+}
+
+func (e *DiffusersEngine) workerStartError(msg string) string {
+	if e.logBuf != nil {
+		if tail := strings.TrimSpace(e.logBuf.String()); tail != "" {
+			msg += "\n\nDiffusers worker output:\n" + tail
+		}
+	}
+	return msg
 }
 
 func writeWorkerScript(runtimeDir string) error {

--- a/internal/logutil/tail_writer.go
+++ b/internal/logutil/tail_writer.go
@@ -1,0 +1,36 @@
+package logutil
+
+import (
+	"bytes"
+	"sync"
+)
+
+// TailWriter keeps only the last maxBytes of data written to it.
+// It is safe for concurrent use by subprocess stdout/stderr writers.
+type TailWriter struct {
+	mu       sync.Mutex
+	buf      bytes.Buffer
+	maxBytes int
+}
+
+func NewTailWriter(maxBytes int) *TailWriter {
+	return &TailWriter{maxBytes: maxBytes}
+}
+
+func (w *TailWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.Write(p)
+	if w.buf.Len() > w.maxBytes {
+		b := w.buf.Bytes()
+		w.buf.Reset()
+		w.buf.Write(b[len(b)-w.maxBytes:])
+	}
+	return len(p), nil
+}
+
+func (w *TailWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}


### PR DESCRIPTION
## Summary
- Avoid installing torchaudio for the Windows embedding runtime and auto-remove broken existing torchaudio installs.
- Verify Windows embedding readiness with real torch/transformers imports so bad runtimes self-heal instead of starting a broken worker.
- Persist embedding and Diffusers worker logs and include the output tail in startup errors.

Fixes https://github.com/OpenCSGs/csglite/issues/54

## Test plan
- go test ./internal/imagegen ./internal/embedding ./internal/server ./internal/config ./internal/logutil


Made with [Cursor](https://cursor.com)