### PR TITLE
Fix column name overlapping in model list table

### DIFF
--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -753,12 +753,12 @@ export function Library() {
         <div class="overflow-x-auto">
           <table class="w-full min-w-[980px] table-fixed text-sm">
             <colgroup>
-              <col class="w-[23%]" />
+              <col class="w-[22%]" />
               <col class="w-[9%]" />
               <col class="w-[10%]" />
               <col class="w-[9%]" />
-              <col class="w-[10%]" />
-              <col class="w-[10%]" />
+              <col class="w-[14%]" />
+              <col class="w-[8%]" />
               <col class="w-[11%]" />
               <col class="w-[18%]" />
             </colgroup>


### PR DESCRIPTION
### Description:
The fifth(column name: Download Progress) and the sixth (column name: Status) columns are overlapping in the Model list table on the Models page.
<img width="2288" height="727" alt="image" src="https://github.com/user-attachments/assets/99393286-9295-49eb-bfe6-4b009a89adf1" />
<img width="2250" height="665" alt="image" src="https://github.com/user-attachments/assets/b3849802-fdfa-465b-b4f1-b79d248c79ef" />


### Solution:
Adjust the width of column to avoid column name overlapping in column name:
<img width="2254" height="638" alt="image" src="https://github.com/user-attachments/assets/33d16604-5154-44fc-9232-e430e966286d" />
<img width="2238" height="633" alt="image" src="https://github.com/user-attachments/assets/dd85f8b4-48b6-4613-b76b-3b8b91adc25a" />

Fixed https://github.com/OpenCSGs/csglite/issues/84




