### PR TITLE
Fix AI gateway toggle styling and remote clipboard copy

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,5 @@
 import "./index.css";
+import "./utils/clipboardPolyfill";
 import { render } from "preact";
 import { App } from "./app";
 

--- a/web/src/pages/AIGateway.tsx
+++ b/web/src/pages/AIGateway.tsx
@@ -1108,7 +1108,7 @@ function LocalAPIKeysSection() {
                 onChange={(e) => void toggleLocalAPIAuth((e.target as HTMLInputElement).checked)}
                 class="peer sr-only"
               />
-              <div class="h-7 w-12 rounded-full bg-gray-200 transition-all after:absolute after:left-[3px] after:top-[3px] after:h-6 after:w-6 after:rounded-full after:border after:border-gray-200 after:bg-white after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-5 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-200 peer-disabled:cursor-not-allowed peer-disabled:opacity-60" />
+              <div class="h-6 w-11 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300 peer-disabled:cursor-not-allowed peer-disabled:opacity-60" />
             </label>
           </div>
           <div class="mt-5 rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
@@ -1365,7 +1365,7 @@ function ProvidersSection() {
 											onChange={() => void toggleProviderEnabled(provider)}
 											class="peer sr-only"
 										/>
-										<div class="h-5 w-9 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300" />
+										<div class="h-5 w-9 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300" />
 									</label>
 								)}
                 </div>
@@ -1891,7 +1891,7 @@ function ProviderDialog({
                   onChange={(e) => onChangeEnabled((e.target as HTMLInputElement).checked)}
                   class="peer sr-only"
                 />
-                <div class="h-6 w-11 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300" />
+                <div class="h-6 w-11 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300" />
               </label>
               <span class="text-sm text-gray-700">{enabled ? t("settings.providerEnabled") : t("settings.providerDisabled")}</span>
             </div>
@@ -2106,7 +2106,7 @@ function ProviderPoolDialog({
                   </div>
                   <label class="relative inline-flex shrink-0 cursor-pointer items-center">
                     <input type="checkbox" checked={enabled} onChange={(event) => onChangeEnabled((event.target as HTMLInputElement).checked)} disabled={saving} class="peer sr-only" />
-                    <div class="h-6 w-11 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300 peer-disabled:opacity-60" />
+                    <div class="h-6 w-11 rounded-full bg-gray-200 transition-all after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:shadow-sm after:transition-all after:content-[''] peer-checked:bg-indigo-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300 peer-disabled:opacity-60" />
                   </label>
                 </div>
               </div>

--- a/web/src/utils/clipboardPolyfill.ts
+++ b/web/src/utils/clipboardPolyfill.ts
@@ -1,0 +1,53 @@
+/**
+ * Clipboard API polyfill for non-secure contexts.
+ *
+ * `navigator.clipboard` is only exposed in secure contexts (HTTPS or
+ * localhost). When the gateway is reached over plain HTTP from a remote
+ * address, `navigator.clipboard` is undefined and every
+ * `navigator.clipboard.writeText(...)` call across the app silently fails.
+ *
+ * This polyfill installs a minimal `writeText` implementation backed by the
+ * legacy `document.execCommand("copy")` path only when the native API is
+ * missing, so localhost / HTTPS keep using the real Clipboard API untouched.
+ * Import once from the app entry; no call site needs to change.
+ */
+function legacyCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
+if (typeof navigator !== "undefined" && !navigator.clipboard) {
+  const writeText = (text: string): Promise<void> => {
+    try {
+      if (legacyCopy(text)) return Promise.resolve();
+    } catch {
+      // fall through to rejection
+    }
+    return Promise.reject(new Error("Clipboard API unavailable"));
+  };
+  try {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  } catch {
+    // Some browsers lock navigator.clipboard; nothing more we can do.
+  }
+}


### PR DESCRIPTION
Two small fixes for the AI gateway page.

## Toggle styling

Standardize all toggle switches in `AIGateway.tsx` to use the same
`peer-checked:after:border-white` treatment as the Settings page, so the
knob border turns white when enabled.

Before:
<img width="3002" height="542" alt="image" src="https://github.com/user-attachments/assets/3b30eed2-b41b-49c9-b0c8-624087eda838" />

After:
<img width="3012" height="552" alt="image" src="https://github.com/user-attachments/assets/632f0a1f-adf1-48a5-a3a4-520bfa910ef3" />

## Remote clipboard copy

`navigator.clipboard` is only available in secure contexts (HTTPS or
localhost). When the gateway is reached over plain HTTP from a remote
address, the API is undefined and every copy button (API key, base URL,
curl example) silently fails.

Install a minimal `writeText` polyfill backed by `document.execCommand`
only when the native clipboard is missing, so localhost/HTTPS keep using
the real API and all existing call sites work unchanged.