### PR TITLE
Make /api/shutdown actually exit the server process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ local/secrets.env
 # llama.cpp CUDA Docker build trees (see scripts/llama-build/README.md)
 scripts/llama-build/work/
 local/llama-build/
+.tool-versions
+.idea
+package-lock.json

--- a/internal/server/handlers_system.go
+++ b/internal/server/handlers_system.go
@@ -321,6 +321,11 @@ func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = s.http.Shutdown(shutCtx)
+		// Stop the Run loop so the process actually exits; closing the
+		// listeners alone leaves it blocked on <-ctx.Done().
+		if s.shutdownCancel != nil {
+			s.shutdownCancel()
+		}
 	}()
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -187,6 +187,11 @@ type Server struct {
 	apiKeys             *config.APIKeyStore
 	apiUsage            *config.APIUsageStore
 	desktopBootstrapped atomic.Bool
+
+	// shutdownCancel stops the Run loop. It is set in Run and invoked by the
+	// /api/shutdown handler so an HTTP-initiated shutdown actually exits the
+	// process instead of only closing the listeners.
+	shutdownCancel context.CancelFunc
 }
 
 type desktopReady struct {
@@ -276,6 +281,7 @@ func resolveCloudURL(cfg *config.Config) string {
 func (s *Server) Run(ctx context.Context) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	s.shutdownCancel = stop
 
 	if s.cfg.DesktopMode {
 		if err := validateDesktopConfig(s.cfg); err != nil {


### PR DESCRIPTION
## Problem

`restart` (and `stop-service`) left a leftover `csghub-lite serve` process behind each time, so processes accumulated.

Root cause: `handleShutdown` only called `s.http.Shutdown()`, which closes the HTTP listeners. But the `Run` loop is blocked on `<-ctx.Done()` waiting for a signal that never comes via the HTTP path, so the process never exits. `stopBackgroundService` polls the health endpoint, sees it go unresponsive, assumes the stop succeeded, and starts a fresh server — while the old process keeps running.

## Fix

Store the `signal.NotifyContext` cancel function on the `Server` and invoke it from `handleShutdown` after closing the listeners. This drives `Run` through the same exit path as `SIGINT`/`SIGTERM` (graceful engine + listener shutdown), so the process actually terminates.

- `http.Server.Shutdown` is idempotent (called once here, once in the Run exit path) — safe.
- `shutdownRuntime` (`closeAllEngines` + `CloseAll`) is idempotent — safe to run twice.
- `shutdownCancel` is nil-guarded; only set in `Run`, which always runs before the route can be hit.

## Note

This prevents *new* orphans from accumulating. Existing leftover processes from before this fix are not auto-cleaned; clear them once with `pkill -f "csghub-lite serve"`.

Before:
<img width="3156" height="278" alt="image" src="https://github.com/user-attachments/assets/f225bdcb-48a4-446b-b694-0bf1d173aebf" />

After:
<img width="3198" height="542" alt="image" src="https://github.com/user-attachments/assets/3f6688aa-3e79-4bbc-aee9-599e2b189e55" />
