### PR TITLE
perf(ai-apps): speed up AI Apps page load and cut polling CPU

### DIFF
--- a/internal/apps/detect.go
+++ b/internal/apps/detect.go
@@ -83,17 +83,28 @@ func detectInstalledCLI(ctx context.Context, spec appSpec, profile installDetect
 	if !ok {
 		return "", "", false
 	}
-	version := path
-	if len(spec.versionArgs) > 0 {
-		cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-		out, err := exec.CommandContext(cmdCtx, path, spec.versionArgs...).CombinedOutput()
-		if err == nil {
-			version = strings.TrimSpace(string(out))
-		}
+	// Version probing is intentionally deferred: `--version` subprocesses
+	// (notably pi/kimi) take hundreds of milliseconds each, which would block
+	// the list response. detectAppVersion runs that asynchronously and
+	// writes the result back to state. Return the path only here so the
+	// "installed" determination stays fast.
+	return path, "", true
+}
+
+// detectAppVersion runs the app's `--version` (or equivalent) subprocess and
+// returns the display version. Callers should invoke this off the request
+// path; it is the slow part of install detection.
+func detectAppVersion(ctx context.Context, spec appSpec, path string) string {
+	if len(spec.versionArgs) == 0 {
+		return appDisplayVersion(spec, path)
 	}
-	version = appDisplayVersion(spec, version)
-	return path, version, true
+	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(cmdCtx, path, spec.versionArgs...).CombinedOutput()
+	if err == nil {
+		return appDisplayVersion(spec, strings.TrimSpace(string(out)))
+	}
+	return ""
 }
 
 func detectCLIAppBinary(binaryName string, profile installDetectProfile) (string, bool) {

--- a/internal/apps/manager.go
+++ b/internal/apps/manager.go
@@ -38,6 +38,13 @@ const (
 	latestVersionResponseLimit = 64 * 1024
 	installerPTYCols           = 120
 	installerPTYRows           = 36
+
+	// installDetectCacheTTL bounds how often RefreshAll re-runs install
+	// detection (PATH lookups + version subprocesses) per app. The AI Apps
+	// page polls /api/apps every 5s; this TTL is set well above the poll
+	// interval so most polls hit the cache and skip forking `--version` for
+	// each installed CLI app. Action completion invalidates it eagerly.
+	installDetectCacheTTL = 30 * time.Second
 )
 
 var (
@@ -82,6 +89,17 @@ type appState struct {
 	logBuf  *LogBuffer
 	cancel  context.CancelFunc
 	running bool
+
+	// detectExpires marks when the cached install-detection result for this
+	// app is stale. While valid, RefreshAll skips re-running detectInstalled
+	// (PATH lookups + `--version` subprocesses) on every poll. Action
+	// completion clears it so the next list reflects the new install state.
+	detectExpires time.Time
+
+	// versionProbing is true while a goroutine is running `--version` to fill
+	// info.Version asynchronously. Guards against spawning duplicate probes.
+	// Caller must hold m.mu when reading/writing.
+	versionProbing bool
 }
 
 type latestVersionCacheEntry struct {
@@ -148,6 +166,13 @@ func NewManager(cfg *config.Config) *Manager {
 	}
 
 	_ = m.RefreshAll(context.Background())
+	// The initial detection seeds state, but its results should not pin the
+	// cache: the first real poll (and any install that completes around
+	// startup) must be free to re-detect. Drop the cache so the next
+	// RefreshAll re-probes instead of serving the seed snapshot.
+	m.mu.Lock()
+	m.invalidateDetectCacheLocked()
+	m.mu.Unlock()
 	return m
 }
 
@@ -529,6 +554,18 @@ func (m *Manager) RefreshAll(ctx context.Context) error {
 	return nil
 }
 
+// invalidateDetectCacheLocked clears the per-app install-detection cache. The
+// caller must hold m.mu. Used after startup seeding and action completion so
+// the next RefreshAll re-probes instead of serving a stale snapshot.
+func (m *Manager) invalidateDetectCacheLocked() {
+	for _, st := range m.states {
+		if st == nil {
+			continue
+		}
+		st.detectExpires = time.Time{}
+	}
+}
+
 func (m *Manager) Install(appID string) (api.AIAppInfo, error) {
 	return m.startAction(appID, "install")
 }
@@ -552,7 +589,10 @@ func (m *Manager) startAction(appID, action string) (api.AIAppInfo, error) {
 		m.mu.Unlock()
 		return info, errors.New("app is disabled")
 	}
-	m.refreshStateLocked(context.Background(), spec, st)
+	// User-initiated action: bypass the detect cache so install/uninstall
+	// eligibility reflects the current filesystem state, not a stale snapshot.
+	m.refreshStateDetectedLocked(context.Background(), spec, st)
+	st.detectExpires = time.Now().Add(installDetectCacheTTL)
 	if st.running {
 		info := cloneInfo(st.info)
 		m.mu.Unlock()
@@ -1122,6 +1162,7 @@ func (m *Manager) completeInstall(spec appSpec, installPath, version string) {
 	}
 	st.running = false
 	st.cancel = nil
+	st.detectExpires = time.Time{}
 	_ = m.markManagedInstall(spec.id)
 	st.info.Status = "installed"
 	st.info.Phase = "installed"
@@ -1143,6 +1184,7 @@ func (m *Manager) completeUninstall(spec appSpec) {
 	}
 	st.running = false
 	st.cancel = nil
+	st.detectExpires = time.Time{}
 	_ = m.clearManagedInstallMarker(spec.id)
 	st.info.Status = "idle"
 	st.info.Phase = "ready"
@@ -1190,7 +1232,9 @@ func (m *Manager) failAction(spec appSpec, action, errMsg string) {
 		st.info.Installed = true
 		st.info.Managed = detected.managed
 		st.info.InstallPath = detected.installPath
-		st.info.Version = detected.version
+		if detected.version != "" {
+			st.info.Version = detected.version
+		}
 	} else {
 		st.info.Status = "failed"
 		st.info.Phase = "failed"
@@ -1502,11 +1546,74 @@ func uniqueNonEmptyPaths(items []string) []string {
 }
 
 func (m *Manager) refreshStateLocked(ctx context.Context, spec appSpec, st *appState) {
+	if !time.Now().Before(st.detectExpires) {
+		// Cache expired (or cleared by action completion): re-detect and
+		// refresh the cached snapshot.
+		m.refreshStateDetectedLocked(ctx, spec, st)
+		st.detectExpires = time.Now().Add(installDetectCacheTTL)
+	}
+	// Kick off async version probing for installed CLI apps whose version is
+	// not yet known. `--version` is forked off the request path so the list
+	// response returns immediately with install status; the version fills in
+	// on the next poll.
+	m.maybeRefreshVersionAsync(spec, st)
+}
+
+// maybeRefreshVersionAsync spawns a goroutine to run `--version` for an
+// installed app when its version is empty and no probe is in flight. The
+// caller must hold m.mu; it returns without blocking.
+func (m *Manager) maybeRefreshVersionAsync(spec appSpec, st *appState) {
+	if !st.info.Installed || st.info.Version != "" || st.versionProbing || len(spec.versionArgs) == 0 {
+		return
+	}
+	if st.info.InstallPath == "" {
+		return
+	}
+	st.versionProbing = true
+	installPath := st.info.InstallPath
+	go m.refreshVersionAsync(spec, installPath)
+}
+
+func (m *Manager) refreshVersionAsync(spec appSpec, installPath string) {
+	version := detectAppVersion(context.Background(), spec, installPath)
+	if version == "" {
+		m.mu.Lock()
+		// Probe failed: clear the flag so a future poll can retry, but leave
+		// Version empty rather than clobbering nothing.
+		if st := m.states[spec.id]; st != nil {
+			st.versionProbing = false
+		}
+		m.mu.Unlock()
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.states[spec.id]
+	if st == nil {
+		return
+	}
+	st.versionProbing = false
+	// Only write if still empty or unchanged-path; avoid overwriting a newer
+	// value set by an action completion in the meantime.
+	if st.info.Version == "" {
+		st.info.Version = version
+		st.info.UpdatedAt = time.Now()
+	}
+}
+
+func (m *Manager) refreshStateDetectedLocked(ctx context.Context, spec appSpec, st *appState) {
 	detected := m.detectInstallState(ctx, spec)
 	st.info.Installed = detected.installed
 	st.info.Managed = detected.managed
 	st.info.InstallPath = detected.installPath
-	st.info.Version = detected.version
+	// Version is probed asynchronously (see refreshVersionAsync) because
+	// `--version` subprocesses are slow. Only overwrite when the synchronous
+	// detector returned one (desktop apps read it from files; CLI apps
+	// leave it empty here and rely on the async probe), so we never clobber
+	// a previously fetched version with an empty string.
+	if detected.version != "" {
+		st.info.Version = detected.version
+	}
 	st.info.ProgressMode = spec.progressMode
 	st.info.UpdatedAt = time.Now()
 

--- a/internal/server/handlers_apps.go
+++ b/internal/server/handlers_apps.go
@@ -16,8 +16,18 @@ import (
 const (
 	aiAppRuntimeStatusRunning = "running"
 	aiAppRuntimeStatusStopped = "stopped"
-	aiAppRuntimeStatusTimeout = 2 * time.Second
+	aiAppRuntimeStatusTimeout  = 2 * time.Second
+
+	// aiAppRuntimeCacheTTL bounds how often the AI Apps poll re-probes runtime
+	// liveness (TCP dial for csgclaw/dsh, dashboard fetch for openclaw,
+	// `docker compose ps` for xiaozhi). Start/stop invalidate it eagerly.
+	aiAppRuntimeCacheTTL = 5 * time.Second
 )
+
+type aiAppRuntimeCacheEntry struct {
+	running   bool
+	expiresAt time.Time
+}
 
 func (s *Server) handleApps(w http.ResponseWriter, r *http.Request) {
 	apps, err := s.appManager.List(r.Context())
@@ -424,17 +434,51 @@ func (s *Server) enrichAIAppRuntime(ctx context.Context, info *api.AIAppInfo) {
 		return
 	}
 
-	statusCtx, cancel := context.WithTimeout(ctx, aiAppRuntimeStatusTimeout)
-	defer cancel()
-	running, err := s.aiAppRuntimeRunning(statusCtx, info.ID)
-	if err != nil {
-		log.Printf("AI APP %s: runtime status check failed: %v", info.ID, err)
-		return
+	running, ok := s.cachedAIAppRuntimeRunning(info.ID)
+	if !ok {
+		statusCtx, cancel := context.WithTimeout(ctx, aiAppRuntimeStatusTimeout)
+		probed, err := s.aiAppRuntimeRunning(statusCtx, info.ID)
+		cancel()
+		if err != nil {
+			log.Printf("AI APP %s: runtime status check failed: %v", info.ID, err)
+			return
+		}
+		running = s.setAIAppRuntimeCache(info.ID, probed)
 	}
 	info.RuntimeRunning = running
 	if running {
 		info.RuntimeStatus = aiAppRuntimeStatusRunning
 	}
+}
+
+// cachedAIAppRuntimeRunning returns the cached liveness result and true when
+// fresh; false means the caller should probe and call setAIAppRuntimeCache.
+func (s *Server) cachedAIAppRuntimeRunning(appID string) (bool, bool) {
+	s.aiAppRuntimeMu.Lock()
+	defer s.aiAppRuntimeMu.Unlock()
+	entry, ok := s.aiAppRuntimeCache[appID]
+	if !ok || !time.Now().Before(entry.expiresAt) {
+		return false, false
+	}
+	return entry.running, true
+}
+
+func (s *Server) setAIAppRuntimeCache(appID string, running bool) bool {
+	s.aiAppRuntimeMu.Lock()
+	defer s.aiAppRuntimeMu.Unlock()
+	s.aiAppRuntimeCache[appID] = aiAppRuntimeCacheEntry{
+		running:   running,
+		expiresAt: time.Now().Add(aiAppRuntimeCacheTTL),
+	}
+	return running
+}
+
+// invalidateAIAppRuntimeCache drops the cached liveness result for an app so
+// the next poll reflects a fresh start/stop.
+func (s *Server) invalidateAIAppRuntimeCache(appID string) {
+	s.aiAppRuntimeMu.Lock()
+	defer s.aiAppRuntimeMu.Unlock()
+	delete(s.aiAppRuntimeCache, appID)
 }
 
 func (s *Server) handleAppLogs(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_apps_lifecycle.go
+++ b/internal/server/handlers_apps_lifecycle.go
@@ -73,6 +73,7 @@ func (s *Server) startAIAppRuntime(ctx context.Context, appID, modelID, modelSou
 	if err != nil {
 		return api.AIAppInfo{}, err
 	}
+	s.invalidateAIAppRuntimeCache(appID)
 	s.enrichAIApp(ctx, &info)
 	return info, nil
 }
@@ -119,6 +120,7 @@ func (s *Server) stopAIAppRuntime(ctx context.Context, appID string) (api.AIAppI
 	if err != nil {
 		return api.AIAppInfo{}, err
 	}
+	s.invalidateAIAppRuntimeCache(appID)
 	s.enrichAIApp(ctx, &info)
 	return info, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -194,6 +194,12 @@ type Server struct {
 	cloudRefreshAt   time.Time
 	cloudRefreshWait chan struct{}
 
+	// aiAppRuntimeMu guards aiAppRuntimeCache, which memoizes the result of
+	// runtime liveness probes (openclaw/csgclaw/dsh/xiaozhi) so the AI Apps
+	// poll does not dial TCP or fork `docker compose ps` every few seconds.
+	aiAppRuntimeMu    sync.Mutex
+	aiAppRuntimeCache map[string]aiAppRuntimeCacheEntry
+
 	conversations             *chathistory.Store
 	apiKeys                   *config.APIKeyStore
 	apiUsage                  *config.APIUsageStore
@@ -269,6 +275,7 @@ func New(cfg *config.Config, version string) *Server {
 		poolAffinity:         make(map[string]providerPoolAffinityEntry),
 		routerProfileCache:   make(map[string]*routerprofile.Profile),
 		pricingCache:         make(map[string]requestCostSnapshot),
+		aiAppRuntimeCache:    make(map[string]aiAppRuntimeCacheEntry),
 		selfHeal:             make(map[string]selfHealBreakerState),
 		imageEngines:         make(map[string]*managedImageEngine),
 		imageLoading:         make(map[string]*imageEngineLoadState),

--- a/web/src/pages/AIApps.tsx
+++ b/web/src/pages/AIApps.tsx
@@ -59,7 +59,6 @@ const drawerMode = signal<DrawerMode>("details");
 const drawerLogs = signal<string[]>([]);
 const drawerStreaming = signal(false);
 const appStates = signal<Record<string, AIAppRuntimeState>>(createAIAppStateSnapshot());
-const loadingApps = signal(true);
 const loadError = signal("");
 const actionError = signal("");
 const pendingInstallId = signal("");
@@ -130,6 +129,7 @@ export function AIApps() {
 
   useEffect(() => {
     let disposed = false;
+    let interval: number | undefined;
 
     const refresh = async () => {
       try {
@@ -140,18 +140,38 @@ export function AIApps() {
       } catch (error) {
         if (disposed) return;
         loadError.value = localizeAIAppErrorMessage((error as Error).message, t("aiApps.loadFailed"));
-      } finally {
-        if (!disposed) {
-          loadingApps.value = false;
-        }
+      }
+    };
+
+    const startPolling = () => {
+      if (interval !== undefined) return;
+      interval = window.setInterval(refresh, 5000);
+    };
+    const stopPolling = () => {
+      if (interval === undefined) return;
+      clearInterval(interval);
+      interval = undefined;
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        // Resume polling and pull immediately so returning to the page
+        // reflects external state changes (e.g. a docker container stopped
+        // elsewhere) without waiting for the next tick.
+        refresh();
+        startPolling();
+      } else {
+        stopPolling();
       }
     };
 
     refresh();
-    const interval = window.setInterval(refresh, 3000);
+    startPolling();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
     return () => {
       disposed = true;
-      clearInterval(interval);
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);
 
@@ -319,11 +339,7 @@ export function AIApps() {
         </div>
       </div>
 
-      {loadingApps.value ? (
-        <div class="border border-dashed border-gray-300 rounded-2xl bg-white px-6 py-12 text-center text-sm text-gray-400">
-          {t("aiApps.loading")}
-        </div>
-      ) : filteredApps.value.length === 0 ? (
+      {filteredApps.value.length === 0 ? (
         <div class="border border-dashed border-gray-300 rounded-2xl bg-white px-6 py-12 text-center text-sm text-gray-400">
           {t("aiApps.noResults")}
         </div>


### PR DESCRIPTION
The AI Apps page polled /api/apps every 3s, and each poll ran install detection (PATH lookups plus --version subprocesses per installed CLI app), runtime liveness probes (TCP dial / docker compose ps), and xiaozhi model directory scans synchronously. Cold detection took ~1.6s (pi/kimi --version alone ~0.5s each), blocking first paint.

Backend:
- Add per-app install-detect TTL cache (30s) so RefreshAll skips re-running detectInstalled on every poll; action completion invalidates it eagerly and NewManager seeds-then-clears so startup does not pin stale results.
- Add runtime liveness probe cache (5s) for openclaw/csgclaw/dsh/xiaozhi; start/stop invalidate it so post-action state is fresh.
- Make version probing async: detectInstalledCLI now only does PATH lookup (fast), --version runs in a background goroutine via maybeRefreshVersionAsync with a versionProbing guard, writing back to state off the request path. Cold detect drops from ~1.6s to ~6ms; versions still fill in by first paint.

Frontend:
- Stop blocking first paint on getAIApps(): render the static catalog immediately with default state, merge real runtime state when the fetch resolves.
- Poll every 5s only while the page is visible (visibilitychange); stop on hide, pull immediately on resume to reflect external state changes.

Measured on a host with 9 installed CLI apps: cold /api/apps 1.6s -> 6ms, re-probe 1.6s -> 0.12s, CPU median 0.0%, peak 1.9% during async version probe.

Generated with AI