### PR TITLE
fix(router): 配置审查加载不出来 + benchmark query 噪声过滤

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/x/xpty v0.1.3
 	github.com/gorilla/websocket v1.5.3
 	github.com/opencsgs/llama-cpp-assets v0.4.0
-	github.com/opencsgs/semantic-router v0.1.0
+	github.com/opencsgs/semantic-router v0.2.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.36.0
 	golang.org/x/sys v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/opencsgs/llama-cpp-assets v0.4.0 h1:abWg/L/9Q4MkmXHwdeME1CVpfmHEpj2NG+BoDy7063g=
 github.com/opencsgs/llama-cpp-assets v0.4.0/go.mod h1:d1LuHSYf9SmFKd1wYOvapbKCkxsGYXe1QVg5ax2+oBo=
-github.com/opencsgs/semantic-router v0.1.0 h1:vhEO+faIT5NqX223Tm7G/fK3WD60NbKK01MmyAAmWa4=
-github.com/opencsgs/semantic-router v0.1.0/go.mod h1:UhkVgKWPma8p18ijmHhaGnUYtiU2WCFWVKg8WP8f/9I=
+github.com/opencsgs/semantic-router v0.2.0 h1:CsfclpYx8N7FmHECofLGDK1FXqtVyiczJI8cfFqsCb0=
+github.com/opencsgs/semantic-router v0.2.0/go.mod h1:UhkVgKWPma8p18ijmHhaGnUYtiU2WCFWVKg8WP8f/9I=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/web/src/pages/AIGateway.tsx
+++ b/web/src/pages/AIGateway.tsx
@@ -2827,7 +2827,7 @@ function RouterV2ProfileReview({ profile }: { profile: ProviderPoolRouterProfile
         <div class="grid gap-4 md:grid-cols-3">
           <RouterSummaryCard label={t("settings.routerBestSingleCost")} value={`${summary.baseline_best_single_model.cost!.toFixed(6)} ${currency}`} />
           <RouterSummaryCard label={t("settings.routerRoutedCost")} value={`${summary.routed.cost!.toFixed(6)} ${currency}`} />
-          <RouterSummaryCard label={t("settings.routerEstimatedSavings")} value={`${summary.savings!.toFixed(6)} ${currency} (${percent(summary.savings_fraction || 0)})`} />
+          <RouterSummaryCard label={t("settings.routerEstimatedSavings")} value={`${(summary.savings ?? 0).toFixed(6)} ${currency} (${percent(summary.savings_fraction || 0)})`} />
         </div>
       ) : (
         <p class="rounded-xl bg-gray-50 p-4 text-sm text-gray-600">{t("settings.routerSavingsUnavailable")}</p>


### PR DESCRIPTION
## 改动

两个相关修复,都针对 pool 优化路由:

### 1. 配置审查加载不出来(toFixed 崩溃)

`RouterV2ProfileReview` 用 `summary.savings!.toFixed(6)` 非空断言,但后端 `Savings` 字段带 `json:"...,omitempty"`。collapsed 到单成员的 profile 里 `Savings=0` 被省略,前端拿到 `undefined`,`undefined.toFixed` 抛 TypeError,Preact 组件崩溃 → 配置审查空白。

改为 `(summary.savings ?? 0).toFixed(6)`。

### 2. benchmark query 噪声过滤(依赖升级)

升级 `semantic-router` v0.1.0 → v0.2.0。新版本在 curation 时过滤 coding agent 注入的 user-role 噪声 turn(`<task-notification>`/`<system-reminder>`/`<tool-use-id>` 等),只取真实用户意图做 routing query 和 embedding。

之前 25 条评估 query 全是同一任务(llama.cpp 升级)的工具通知片段,导致校准塌缩到单成员。过滤后 128 条历史请求产出 53 个 distinct 真实 query。

## 验证

- Chrome CDP 实测:配置审查完整渲染,0 异常
- semantic-router 集成测试:过滤前全是 task-notification/URL,过滤后 53 distinct 真实 query,0 markup 残留
- `go build` + `golangci-lint` 通过

## 关联

- semantic-router v0.2.0: https://github.com/OpenCSGs/semantic-router/releases/tag/v0.2.0

Generated with AI