### PR TITLE
fix: remove unsupported "thinking" param from evaluation judge request to avoid 400 error on non-thinking models

### DIFF
--- a/internal/inference/openai.go
+++ b/internal/inference/openai.go
@@ -634,6 +634,15 @@ func openAIModelUsesThinkingTypeDisabled(modelName string) bool {
 		strings.HasPrefix(modelName, "mimo-")
 }
 
+// OpenAIModelUsesThinkingTypeDisabled reports whether the model family disables
+// reasoning via the "thinking": {"type": "disabled"} request field. Callers that
+// build requests directly (such as the evaluation judge) use it to send the field
+// only to models that accept it; strict OpenAI-compatible endpoints reject
+// unrecognized arguments like "thinking" with a 400.
+func OpenAIModelUsesThinkingTypeDisabled(modelName string) bool {
+	return openAIModelUsesThinkingTypeDisabled(modelName)
+}
+
 func openAIModelSupportsEnableThinkingFalse(modelName string) bool {
 	modelName = strings.TrimSpace(strings.ToLower(modelName))
 	return strings.HasPrefix(modelName, "qwen3") ||

--- a/internal/server/provider_pool_evaluation.go
+++ b/internal/server/provider_pool_evaluation.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/opencsgs/csglite/internal/config"
 	"github.com/opencsgs/csglite/internal/inference"
-	routerprofile "github.com/opencsgs/semantic-router"
 	"github.com/opencsgs/csglite/pkg/api"
+	routerprofile "github.com/opencsgs/semantic-router"
 )
 
 const (
@@ -1120,6 +1120,15 @@ func (s *Server) evaluationChatCompletion(ctx context.Context, model, source str
 	if judge {
 		request["temperature"] = 0
 		request["response_format"] = map[string]interface{}{"type": "json_object"}
+		// Only reasoning model families accept the "thinking" field (GLM, Kimi,
+		// Moonshot, DeepSeek-V4, Mimo). Sending it unconditionally makes strict
+		// OpenAI-compatible endpoints such as GPT-4.1 mini reject the request
+		// with 400: Unrecognized request argument supplied: thinking. Qwen3/QwQ
+		// judges do not need the field here: the cloud engine already injects
+		// enable_thinking=false via sanitizeOpenAIRequestBody.
+		if inference.OpenAIModelUsesThinkingTypeDisabled(model) {
+			request["thinking"] = map[string]interface{}{"type": "disabled"}
+		}
 	}
 	response, err := proxy.ChatCompletion(ctx, request)
 	result := evaluationCallResult{latency: time.Since(started)}

--- a/internal/server/provider_pool_evaluation.go
+++ b/internal/server/provider_pool_evaluation.go
@@ -1120,7 +1120,6 @@ func (s *Server) evaluationChatCompletion(ctx context.Context, model, source str
 	if judge {
 		request["temperature"] = 0
 		request["response_format"] = map[string]interface{}{"type": "json_object"}
-		request["thinking"] = map[string]interface{}{"type": "disabled"}
 	}
 	response, err := proxy.ChatCompletion(ctx, request)
 	result := evaluationCallResult{latency: time.Since(started)}

--- a/internal/server/provider_pool_evaluation_test.go
+++ b/internal/server/provider_pool_evaluation_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/opencsgs/csglite/internal/config"
 	"github.com/opencsgs/csglite/internal/inference"
-	routerprofile "github.com/opencsgs/semantic-router"
 	"github.com/opencsgs/csglite/pkg/api"
+	routerprofile "github.com/opencsgs/semantic-router"
 )
 
 type evaluationFakeEngine struct {
@@ -294,6 +294,11 @@ func TestProviderPoolEvaluationJudgeRetriesStrictJSONAndAccountsBudget(t *testin
 			if format["type"] != "json_object" || body["max_tokens"] != providerPoolJudgeMaxTokens {
 				t.Fatalf("judge strict request = %#v", body)
 			}
+			// "judge" is not a reasoning model family, so the thinking field must
+			// be omitted: strict OpenAI-compatible endpoints reject it with 400.
+			if _, hasThinking := body["thinking"]; hasThinking {
+				t.Fatalf("judge request must not carry thinking for model %q: %#v", model, body["thinking"])
+			}
 			switch judgeCalls {
 			case 1:
 				return evaluationResponse("", 20, 0), nil
@@ -324,6 +329,51 @@ func TestProviderPoolEvaluationJudgeRetriesStrictJSONAndAccountsBudget(t *testin
 		cells[0].JudgeAttemptCount != 3 || cells[0].JudgeScore != .75 ||
 		cells[0].JudgeTotalTokens != 68 || cells[0].EstimatedCost > request.BudgetAmount+1e-12 {
 		t.Fatalf("retry result = %+v calls=%d/%d budget=%f", cells[0], candidateCalls, judgeCalls, request.BudgetAmount)
+	}
+}
+
+func TestProviderPoolEvaluationJudgeThinkingSuppressionByModelFamily(t *testing.T) {
+	cases := []struct {
+		model      string
+		suppressed bool
+	}{
+		{"glm-5.1", true},
+		{"deepseek-v4-pro", true},
+		{"kimi-k2-thinking", true},
+		{"moonshot-v1", true},
+		{"gpt-4.1-mini", false},
+		{"qwen3-235b", false}, // suppressed via engine enable_thinking=false, not the thinking field
+		{"judge", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			s := evaluationTestServer(t, []config.ProviderPoolMember{
+				{ID: "member", Source: "cloud", Model: "candidate"},
+			})
+			var captured map[string]interface{}
+			s.evaluationEngineFactory = func(_ context.Context, model, _ string) (inference.Engine, error) {
+				return &evaluationFakeEngine{model: model, call: func(_ context.Context, body map[string]interface{}) (*http.Response, error) {
+					captured = body
+					return evaluationResponse(`{"score":0.5,"reason":"ok"}`, 10, 5), nil
+				}}, nil
+			}
+			_, err := s.evaluationChatCompletion(t.Context(), tc.model, "cloud",
+				[]routerprofile.Message{{Role: "user", Content: "judge prompt"}}, providerPoolJudgeMaxTokens, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			thinking, hasThinking := captured["thinking"].(map[string]interface{})
+			if tc.suppressed {
+				if !hasThinking || thinking["type"] != "disabled" {
+					t.Fatalf("judge thinking suppression missing for %q: %#v", tc.model, captured["thinking"])
+				}
+			} else if hasThinking {
+				t.Fatalf("judge request must not carry thinking for %q: %#v", tc.model, captured["thinking"])
+			}
+			if format, _ := captured["response_format"].(map[string]interface{}); format["type"] != "json_object" {
+				t.Fatalf("judge response_format missing for %q: %#v", tc.model, captured["response_format"])
+			}
+		})
 	}
 }
 

--- a/internal/server/provider_pool_evaluation_test.go
+++ b/internal/server/provider_pool_evaluation_test.go
@@ -291,9 +291,7 @@ func TestProviderPoolEvaluationJudgeRetriesStrictJSONAndAccountsBudget(t *testin
 				t.Fatalf("judge temperature = %#v", body["temperature"])
 			}
 			format, _ := body["response_format"].(map[string]interface{})
-			thinking, _ := body["thinking"].(map[string]interface{})
-			if format["type"] != "json_object" || thinking["type"] != "disabled" ||
-				body["max_tokens"] != providerPoolJudgeMaxTokens {
+			if format["type"] != "json_object" || body["max_tokens"] != providerPoolJudgeMaxTokens {
 				t.Fatalf("judge strict request = %#v", body)
 			}
 			switch judgeCalls {


### PR DESCRIPTION

fix: remove unsupported "thinking" param from evaluation judge request                                                                             
                                                                                                                                                        
The evaluationChatCompletion function hard-coded `thinking: {"type": "disabled"}` in the judge request body, but not all upstream models support this parameter. Models like 'GPT-4.1 mini' reject it with "400: Unrecognized request argument supplied:  thinking", causing the entire Listwise evaluation job to fail.                                                                                                                                                   
The thinking-disable intent is already handled downstream by the engine layer:  sanitizeOpenAIRequestBody() applies `enable_thinking: false` or `thinking: {type:   "disabled"}` only for models that are known to support it (Qwen3, QwQ, GLM, etc.).   Removing the unconditional hard-code lets the engine decide per-model, fixing the 400 error on non-thinking models while preserving the disable behavior where supported. 

Fix https://github.com/OpenCSGs/csglite/issues/131