### PR TITLE
Fix 2 failing tests related to temp directory in dev env

### DIFF
--- a/internal/server/handlers_audio_test.go
+++ b/internal/server/handlers_audio_test.go
@@ -72,11 +72,6 @@ func (e *failingStreamASREngine) ModelName() string {
 }
 
 func TestHandleOpenAIAudioTranscriptionsUsesLiteTempDir(t *testing.T) {
-	missingTempDir := filepath.Join(t.TempDir(), "missing-temp")
-	t.Setenv("TMPDIR", missingTempDir)
-	t.Setenv("TMP", missingTempDir)
-	t.Setenv("TEMP", missingTempDir)
-
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	if err := writer.WriteField("model", "missing-asr-model"); err != nil {
@@ -102,6 +97,13 @@ func TestHandleOpenAIAudioTranscriptionsUsesLiteTempDir(t *testing.T) {
 		DatasetDir: config.DatasetDirForStorage(storageDir),
 	}
 	s := newTestServerWithConfig(t, cfg)
+
+	// Set TMPDIR after server init so apps.NewManager does not recreate it.
+	missingTempDir := filepath.Join(t.TempDir(), "missing-temp")
+	t.Setenv("TMPDIR", missingTempDir)
+	t.Setenv("TMP", missingTempDir)
+	t.Setenv("TEMP", missingTempDir)
+
 	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	w := httptest.NewRecorder()

--- a/internal/server/handlers_images_test.go
+++ b/internal/server/handlers_images_test.go
@@ -215,11 +215,6 @@ func TestHandleOpenAIImagesEditsForwardsInputImage(t *testing.T) {
 }
 
 func TestHandleOpenAIImagesEditsAvoidsSystemTempDir(t *testing.T) {
-	missingTempDir := filepath.Join(t.TempDir(), "missing-temp")
-	t.Setenv("TMPDIR", missingTempDir)
-	t.Setenv("TMP", missingTempDir)
-	t.Setenv("TEMP", missingTempDir)
-
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	_ = writer.WriteField("model", "Qwen/Qwen-Image-Edit-2511")
@@ -239,6 +234,13 @@ func TestHandleOpenAIImagesEditsAvoidsSystemTempDir(t *testing.T) {
 		DatasetDir: config.DatasetDirForStorage(storageDir),
 	}
 	s := newTestServerWithConfig(t, cfg)
+
+	// Set TMPDIR after server init so apps.NewManager does not recreate it.
+	missingTempDir := filepath.Join(t.TempDir(), "missing-temp")
+	t.Setenv("TMPDIR", missingTempDir)
+	t.Setenv("TMP", missingTempDir)
+	t.Setenv("TEMP", missingTempDir)
+
 	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	w := httptest.NewRecorder()


### PR DESCRIPTION

go test -race -count=1 -run TestHandleOpenAIAudioTranscriptionsUsesLiteTempDir  ./internal/server
go test -race -count=1 -run TestHandleOpenAIImagesEditsAvoidsSystemTempDir  ./internal/server

<img width="742" height="238" alt="image" src="https://github.com/user-attachments/assets/a5ee2551-b6b4-4210-8d8c-aa6ba104d70c" />

