### PR TITLE
feat(llama-build): add Ubuntu 22.04 ROCm x64 mirror build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ hooks:
 release-snapshot: build-web
 	goreleaser release --snapshot --clean
 
-# Ubuntu 22.04 CUDA llama.cpp mirrors for GitLab (see scripts/llama-build/README.md)
+# Ubuntu 22.04 CUDA/ROCm llama.cpp mirrors for GitLab (see scripts/llama-build/README.md)
 LLAMA_TAG ?= b10830
 
 llama-cuda-rebuild-all:
@@ -102,6 +102,10 @@ llama-cuda-rebuild-x64:
 llama-cuda-rebuild-arm64:
 	chmod +x scripts/llama-build/*.sh
 	./scripts/llama-build/rebuild-upload-arm64.sh $(LLAMA_TAG)
+
+llama-rocm-rebuild-x64:
+	chmod +x scripts/llama-build/*.sh
+	./scripts/llama-build/rebuild-upload-rocm-x64.sh $(LLAMA_TAG)
 
 clean:
 	rm -rf bin/ dist/ coverage.out coverage.html

--- a/docs/agent-guidelines/llama-cpp.md
+++ b/docs/agent-guidelines/llama-cpp.md
@@ -93,6 +93,34 @@ For each new tag, after version lockstep is updated:
 Use `hybridgroup/llama-cpp-builder` only as an optional **layout reference** (tar
 paths, CUDA naming), not as a binary to re-upload.
 
+### Ubuntu Linux ROCm — local Docker build only
+
+Upstream **does** publish `llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz` from
+b10830 onward, but its release workflow runs that job on `ubuntu-24.04`. Those
+tarballs require `GLIBC_2.38` / `GLIBCXX_3.4.32` and fail to start on the
+Ubuntu 22.04 ROCm runtime image in `docker/rocm/Dockerfile`. **Do not mirror
+them.** Treat ROCm exactly like CUDA: build it locally on 22.04.
+
+The ROCm series in the filename is not cosmetic. `scripts/install.sh` derives it
+from the host (`CSGHUB_LITE_LLAMA_ROCM_VERSION`, `/opt/rocm/.info/version`,
+`hipcc`) and asks for that exact series first. If the series-specific package is
+missing, the installer falls back to any published ROCm asset for the tag —
+which is how a 24.04 / ROCm 10.0 build reached a 22.04 / ROCm 7.2 host. Mirror
+the series that `docker/rocm/Dockerfile` actually runs (currently 7.2) for every
+tag, or that fallback fires again.
+
+For each new tag, after version lockstep is updated:
+
+1. Build with `scripts/llama-build/rebuild-upload-rocm-x64.sh` (Ubuntu 22.04,
+   pinned `rocm/dev-ubuntu-22.04:<series>-complete` image).
+2. Verify on 22.04 (see below).
+3. Upload `llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz` to GitLab.
+
+`GPU_TARGETS` defaults to the gfx coverage of the last mirrored ROCm package
+(b9158): `gfx908;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201`.
+Narrow it only when a build is for one known card; widening it costs build time
+and package size roughly linearly.
+
 ## Ubuntu CUDA Mirror
 
 Linux CUDA packages are **built locally**, then mirrored to GitLab generic
@@ -103,15 +131,17 @@ download them on Ubuntu 22.04 hosts.
 
 ```sh
 make llama-cuda-rebuild-all LLAMA_TAG=b10830   # or ./scripts/llama-build/rebuild-upload-all.sh
+make llama-rocm-rebuild-x64 LLAMA_TAG=b10830   # ROCm is a separate target
 ```
 
 ### Why Ubuntu 22.04 in Docker
 
-Packages built on Ubuntu **24.04** (or hybridgroup amd64 CI images) link against
-`GLIBC_2.38` / `GLIBCXX_3.4.32` and fail on 22.04 with errors like
-`version 'GLIBC_2.38' not found`. Always compile inside
-`nvidia/cuda:12.9.1-devel-ubuntu22.04` for GitLab mirrors intended for 22.04
-users.
+Packages built on Ubuntu **24.04** (upstream's ROCm job, or hybridgroup amd64 CI
+images) link against `GLIBC_2.38` / `GLIBCXX_3.4.32` and fail on 22.04 with
+errors like `version 'GLIBC_2.38' not found`. Always compile inside
+`nvidia/cuda:12.9.1-devel-ubuntu22.04` (CUDA) or
+`rocm/dev-ubuntu-22.04:<series>-complete` (ROCm) for GitLab mirrors intended for
+22.04 users.
 
 ### Local Docker images (reuse)
 
@@ -122,6 +152,7 @@ user explicitly asks to reclaim disk space.
 | Image | Platforms |
 |-------|-----------|
 | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | `linux/amd64` (x64), `linux/arm64` |
+| `rocm/dev-ubuntu-22.04:7.2.2-complete` | `linux/amd64` (x64) |
 
 On Apple Silicon, pull **both** platforms (same tag, different manifests). Prefer
 `docker image inspect --platform …` and `docker run --pull=never` when the image
@@ -135,6 +166,7 @@ Workdirs (`scripts/llama-build/work/`) are gitignored; only scripts are committe
 |------|----------|------------|
 | x64 | `llama-<tag>-bin-ubuntu-cuda-x64.tar.gz` | `bin/llama-server` + `lib/` at tar root |
 | arm64 | `llama-<tag>-bin-ubuntu-cuda-arm64.tar.gz` | `llama-<tag>-bin-ubuntu-cuda-arm64/{bin,lib}/` |
+| rocm x64 | `llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz` | `bin/llama-server` + `lib/` at tar root |
 
 `scripts/install.sh` also tries legacy names such as
 `llama-<tag>-bin-ubuntu-cuda-12.4-<arch>.tar.gz`; new mirrors for b9158+ use the
@@ -171,14 +203,32 @@ Older layout references for comparison only:
 - Do **not** pass host `http_proxy` into the arm64 container (`apt` may fail via
   `host.docker.internal:7890`)
 
+**rocm x64**
+
+- Same packaging flags as CUDA x64, with `GGML_HIP=ON`, `HIP_PLATFORM=amd`, and
+  `GPU_TARGETS` instead of `CMAKE_CUDA_ARCHITECTURES`
+- `-DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang"`; do not set `CXX=hipcc`, which
+  llama.cpp now warns about as legacy
+- Install **CMake 3.31.x**, not 4.x: the HIP language needs ≥ 3.21, but CMake 4
+  removed `cmake_minimum_required(<3.5)` compatibility that ROCm CMake config
+  packages still declare
+- Pack: `cp -a build/bin/lib*.so*` into `lib/` (preserve symlinks); check
+  `libggml-hip.so` is present
+
 ### Verify before upload
 
 1. Tar layout matches the reference package for that arch (see
    `compare-with-gitlab.sh`).
-2. `libggml-cuda.so` present; `file` reports correct architecture.
+2. `libggml-cuda.so` (CUDA) or `libggml-hip.so` (ROCm) present; `file` reports
+   correct architecture.
 3. In the **22.04 CUDA image** on the matching platform, with packaged `lib/` on
    `LD_LIBRARY_PATH`, `llama-server --version` succeeds (no `GLIBC_2.38` / missing
    `GLIBCXX_3.4.32` on ref or new build).
+4. ROCm packages additionally run `ldd` over every packaged object in a plain
+   `ubuntu:22.04` container: no `version 'GLIBC_*'` / `version 'GLIBCXX_*'`
+   errors. Missing `libamdhip64` / `librocblas` there is expected. `--version`
+   cannot fully validate a ROCm build without `/dev/kfd`, so final confirmation
+   belongs on an AMD GPU host.
 
 ### Linux NVIDIA runtime dependencies
 
@@ -227,6 +277,7 @@ and is much slower than native arm64.
 | Disk full / Docker engine dead | Free space without deleting pinned images; restart Docker Desktop |
 | Only one platform of CUDA image pulled | `docker pull --platform linux/amd64` and `linux/arm64` |
 | x64 linked to GLIBC 2.38 | Build in 22.04, not 24.04 |
+| ROCm host installs a 24.04 / wrong-series package | Mirror `rocm-<series>-x64` for the tag; the installer falls back to any ROCm asset when the series is missing |
 | arm64 `-march=armv9.2-a` compile error | GCC 14 |
 | arm64 `GLIBCXX_3.4.32 not found` at runtime | Bundle GCC 14 `libstdc++` in tarball |
 | Missing `libggml-base.so.0` at runtime | `cp -a build/bin/lib*.so*` (not `libggml-*.so` glob alone) |

--- a/scripts/llama-build/README.md
+++ b/scripts/llama-build/README.md
@@ -1,7 +1,8 @@
-# llama.cpp Ubuntu 22.04 CUDA mirror builds
+# llama.cpp Ubuntu 22.04 CUDA/ROCm mirror builds
 
-Scripts to build `llama-<tag>-bin-ubuntu-cuda-{x64,arm64}.tar.gz` on **Ubuntu 22.04**
-inside Docker and upload to GitLab generic packages.
+Scripts to build `llama-<tag>-bin-ubuntu-cuda-{x64,arm64}.tar.gz` and
+`llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz` on **Ubuntu 22.04** inside
+Docker and upload to GitLab generic packages.
 
 Canonical rules: [`docs/agent-guidelines/llama-cpp.md`](../../docs/agent-guidelines/llama-cpp.md).
 
@@ -11,15 +12,26 @@ Canonical rules: [`docs/agent-guidelines/llama-cpp.md`](../../docs/agent-guideli
 |----------|--------|
 | Converter, CPU/macOS/Windows assets upstream publishes | **Official** `ggml-org/llama.cpp` GitHub releases → mirror to GitLab |
 | **Ubuntu Linux CUDA** (`*-ubuntu-cuda-x64.tar.gz`, `*-ubuntu-cuda-arm64.tar.gz`) | **This directory** — Docker build on 22.04, then upload to GitLab |
+| **Ubuntu Linux ROCm** (`*-ubuntu-rocm-<series>-x64.tar.gz`) | **This directory** — Docker build on 22.04, then upload to GitLab |
 
 Do **not** sync Ubuntu CUDA binaries from `hybridgroup/llama-cpp-builder`; use it
 only to compare tar layout if needed.
+
+Do **not** mirror upstream's `llama-<tag>-bin-ubuntu-rocm-*.tar.gz` either.
+Upstream started publishing a Linux ROCm asset at b10830, but its release
+workflow builds that job on `ubuntu-24.04`, so the result needs `GLIBC_2.38` /
+`GLIBCXX_3.4.32` and cannot start on the 22.04 ROCm runtime image in
+`docker/rocm/Dockerfile`. The ROCm series in the filename must also match that
+runtime image (currently 7.2), not whatever series upstream happens to ship.
 
 ## Prerequisites
 
 - Docker Desktop (engine running). On Apple Silicon, pull **both** platforms of the
   pinned image (scripts do this automatically when missing).
-- ~30GB free disk for images + two build trees.
+- ~30GB free disk for images + two CUDA build trees. A ROCm build needs
+  considerably more: the `rocm/dev-ubuntu-22.04` image alone is ~7.3GB, and
+  `libggml-hip.so` carries device code for every requested `gfx` target (~590MB
+  for the default ten), so budget ~60GB for its tree.
 - `local/secrets.env` with `GITLAB_TOKEN` for uploads (`unset` proxy before GitLab).
 - GitHub clone: `source ~/.myshrc` if you need a proxy for `git clone`.
 
@@ -38,6 +50,13 @@ make llama-cuda-rebuild-all
 # One architecture only:
 ./scripts/llama-build/rebuild-upload-x64.sh b10830
 ./scripts/llama-build/rebuild-upload-arm64.sh b10830
+
+# ROCm x64 (separate target; not part of rebuild-upload-all.sh)
+make llama-rocm-rebuild-x64
+./scripts/llama-build/rebuild-upload-rocm-x64.sh b10830
+
+# Build and verify without publishing
+LLAMA_BUILD_SKIP_UPLOAD=1 ./scripts/llama-build/rebuild-upload-rocm-x64.sh b10830
 ```
 
 Artifacts: `scripts/llama-build/work/out/*.tar.gz` (gitignored).
@@ -47,15 +66,23 @@ Compare with GitLab before/after upload:
 ```sh
 ./scripts/llama-build/compare-with-gitlab.sh x64 b10830
 ./scripts/llama-build/compare-with-gitlab.sh arm64 b10830
+./scripts/llama-build/compare-with-gitlab.sh rocm-x64 b10830
 ```
 
-## Pinned Docker image
+## Pinned Docker images
 
-| Image | Platforms |
-|-------|-----------|
-| `nvidia/cuda:12.9.1-devel-ubuntu22.04` | `linux/amd64`, `linux/arm64` |
+| Image | Platforms | Used for |
+|-------|-----------|----------|
+| `nvidia/cuda:12.9.1-devel-ubuntu22.04` | `linux/amd64`, `linux/arm64` | CUDA build + verify |
+| `rocm/dev-ubuntu-22.04:7.2.2-complete` | `linux/amd64` | ROCm build + verify |
+| `ubuntu:22.04` | `linux/amd64` | ROCm glibc-baseline check |
 
-Scripts reuse local images (`docker image inspect` / `--pull=never`).
+Scripts reuse local images (`docker image inspect` / `--pull=never`). Override with
+`LLAMA_BUILD_CUDA_IMAGE`, `LLAMA_BUILD_ROCM_IMAGE`, `LLAMA_BUILD_UBUNTU_IMAGE`.
+
+Keep `LLAMA_BUILD_ROCM_IMAGE` and `LLAMA_BUILD_ROCM_SERIES` in lockstep with the
+base image in `docker/rocm/Dockerfile`; the series string ends up in the package
+filename that `scripts/install.sh` looks for.
 
 ## Package layout (b10830 reference)
 
@@ -63,6 +90,11 @@ Scripts reuse local images (`docker image inspect` / `--pull=never`).
 |------|---------|-------------|
 | x64 | `llama-<tag>-bin-ubuntu-cuda-x64.tar.gz` | `bin/llama-server` + `lib/*.so*` at tar root |
 | arm64 | `llama-<tag>-bin-ubuntu-cuda-arm64.tar.gz` | `llama-<tag>-bin-ubuntu-cuda-arm64/{bin,lib}/` with five CLI tools |
+| rocm x64 | `llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz` | `bin/llama-server` + `lib/*.so*` at tar root |
+
+`scripts/install.sh` flattens whichever layout it downloads into a single
+directory, and `ggml_backend_load_all` searches the executable's own directory,
+so backend `.so` files still load after the flattening.
 
 Upload URL pattern:
 
@@ -82,6 +114,25 @@ Override CUDA arch for a one-off build:
 docker run ... -e CMAKE_CUDA_ARCHITECTURES="80;86;89" ...
 ```
 
+### ROCm x64
+
+| Setting | Value |
+|---------|-------|
+| `GPU_TARGETS` | `gfx908;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201` |
+| Toolchain | ROCm 7.2.2 clang from the dev image (`CMAKE_HIP_COMPILER=$(hipconfig -l)/clang`) |
+| CMake | 3.31.6, **not** 4.x — CMake 4 removed `cmake_minimum_required(<3.5)` support that ROCm config packages still declare |
+| CMake flags | `GGML_HIP=ON`, `HIP_PLATFORM=amd`, `GGML_BACKEND_DL=ON`, `GGML_CPU_ALL_VARIANTS=ON`, `GGML_NATIVE=OFF` |
+
+The default `GPU_TARGETS` reproduces the coverage of the last mirrored ROCm
+package (b9158, rocm-7.2). Build time scales with this list, so narrow it when
+you only need one card:
+
+```sh
+GPU_TARGETS="gfx1100" ./scripts/llama-build/rebuild-upload-rocm-x64.sh b10830
+```
+
+Read the target off the host with `rocminfo | grep gfx`.
+
 ## Troubleshooting
 
 | Symptom | Fix |
@@ -92,13 +143,17 @@ docker run ... -e CMAKE_CUDA_ARCHITECTURES="80;86;89" ...
 | x64: `GLIBC_2.38 not found` on 22.04 | Rebuild in 22.04 image, not 24.04 |
 | `libggml-base.so.0: cannot open shared object` | Pack with `cp -a build/bin/lib*.so*` (keeps symlinks) |
 | apt fails in arm64 container | Do not pass host `http_proxy` into the container |
-| Apple Silicon amd64 build very slow | Expected (QEMU); arm64 build is native |
+| Apple Silicon amd64 build very slow | Expected (QEMU); arm64 build is native. A multi-target ROCm build is impractical this way — use an x86_64 Linux builder or narrow `GPU_TARGETS` |
+| ROCm: `Compatibility with CMake < 3.5 has been removed` | A CMake 4.x leaked into the container; the script pins 3.31.6 via `CMAKE_VERSION` |
+| ROCm: `--version` exits non-zero in the container | Expected without `/dev/kfd`; the `ldd` and glibc-baseline checks are the gates. Validate for real on an AMD GPU host |
+| ROCm: installed but `no usable GPU found` on the host | Series mismatch — the package's `libggml-hip.so` needs the host's `libamdhip64`/`librocblas`/`libhipblas` sonames |
 
 ## Files
 
 | File | Role |
 |------|------|
 | `common.sh` | Docker/GitLab helpers |
-| `build-ubuntu22-cuda-*.sh` | In-container compile + pack |
+| `build-ubuntu22-cuda-*.sh` | In-container CUDA compile + pack |
+| `build-ubuntu22-rocm-x64.sh` | In-container ROCm compile + pack |
 | `rebuild-upload-*.sh` | Host driver: clone, docker run, verify, upload |
 | `compare-with-gitlab.sh` | Diff layout + runtime vs remote package |

--- a/scripts/llama-build/build-ubuntu22-rocm-x64.sh
+++ b/scripts/llama-build/build-ubuntu22-rocm-x64.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Run inside: rocm/dev-ubuntu-22.04:<rocm>-complete (linux/amd64). Keep image locally; do not prune.
+#
+# Upstream ggml-org builds its ubuntu-rocm assets on Ubuntu 24.04, so those
+# tarballs need GLIBC_2.38 / GLIBCXX_3.4.32 and cannot run on 22.04 hosts such
+# as docker/rocm/Dockerfile's ROCm image. This script produces the 22.04
+# equivalent that scripts/install.sh expects at
+# llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz.
+set -euo pipefail
+
+TAG="${LLAMA_TAG:-b10830}"
+ROCM_SERIES="${ROCM_SERIES:-7.2}"
+WORKDIR="${WORKDIR:-/work}"
+OUTDIR="${OUTDIR:-/out}"
+ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+# Default gfx list matches the previously mirrored ROCm package
+# (b9158, rocm-7.2). Override with GPU_TARGETS for a smaller/faster build.
+GPU_TARGETS="${GPU_TARGETS:-gfx908;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201}"
+# CMake >= 3.21 is required for the HIP language. Stay on 3.x here: CMake 4
+# removed compatibility with cmake_minimum_required(<3.5), which some ROCm
+# CMake config packages still declare.
+CMAKE_VERSION="${CMAKE_VERSION:-3.31.6}"
+
+export DEBIAN_FRONTEND=noninteractive
+export PATH="${ROCM_PATH}/bin:${PATH}"
+
+apt-get update -qq
+apt-get install -y -qq \
+  build-essential ninja-build libgomp1 git libssl-dev libcurl4-openssl-dev wget ca-certificates file
+
+mkdir -p /tmp/cmake-install
+cd /tmp/cmake-install
+wget -q -O cmake.sh "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh"
+sh cmake.sh --prefix=/usr/local --skip-license
+cd /
+rm -rf /tmp/cmake-install
+
+mkdir -p "${WORKDIR}"
+cd "${WORKDIR}/llama.cpp"
+if [ ! -d .git ]; then
+  git clone --depth 1 --branch "${TAG}" https://github.com/ggml-org/llama.cpp.git .
+else
+  git fetch --depth 1 origin "refs/tags/${TAG}" 2>/dev/null || true
+  git checkout "${TAG}" 2>/dev/null || true
+fi
+
+echo "=== ROCm toolchain ==="
+hipconfig --version
+echo "GPU_TARGETS=${GPU_TARGETS}"
+
+cmake -S . -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+  -DCMAKE_PREFIX_PATH="${ROCM_PATH}" \
+  -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DGGML_NATIVE=OFF \
+  -DGGML_CPU_ALL_VARIANTS=ON \
+  -DGGML_HIP=ON \
+  -DHIP_PLATFORM=amd \
+  -DGPU_TARGETS="${GPU_TARGETS}" \
+  -DGGML_BACKEND_DL=ON \
+  -DGGML_BACKEND_DIR:STRING=lib
+
+cmake --build build --config Release -j "$(nproc)"
+
+rm -rf "${OUTDIR}/stage"
+mkdir -p "${OUTDIR}/stage/bin" "${OUTDIR}/stage/lib"
+cp -a build/bin/llama-server "${OUTDIR}/stage/bin/"
+shopt -s nullglob
+for lib in build/bin/lib*.so*; do
+  cp -a "${lib}" "${OUTDIR}/stage/lib/"
+done
+shopt -u nullglob
+
+test -f "${OUTDIR}/stage/lib/libggml-hip.so"
+file "${OUTDIR}/stage/bin/llama-server" "${OUTDIR}/stage/lib/libggml-hip.so"
+
+# Hard check: every shared-library dependency must resolve. This is the part
+# that catches a wrong-OS or wrong-ROCm build.
+echo "=== ldd (must not report 'not found') ==="
+missing=0
+for target in "${OUTDIR}/stage/bin/llama-server" "${OUTDIR}"/stage/lib/*.so*; do
+  [ -f "${target}" ] || continue
+  if LD_LIBRARY_PATH="${OUTDIR}/stage/lib:${ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}" \
+      ldd "${target}" 2>/dev/null | grep -q 'not found'; then
+    echo "MISSING deps in $(basename "${target}"):"
+    LD_LIBRARY_PATH="${OUTDIR}/stage/lib:${ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}" \
+      ldd "${target}" | grep 'not found'
+    missing=1
+  fi
+done
+[ "${missing}" -eq 0 ] || { echo "unresolved shared library dependencies" >&2; exit 1; }
+
+# Informational only: the build container has no /dev/kfd, so the HIP backend
+# cannot initialise here. Final GPU validation must happen on an AMD host.
+echo "=== llama-server --version (no GPU in build container) ==="
+LD_LIBRARY_PATH="${OUTDIR}/stage/lib:${ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}" \
+  "${OUTDIR}/stage/bin/llama-server" --version || \
+  echo "WARN: --version exited non-zero without a GPU; check the ldd output above."
+
+cd "${OUTDIR}/stage"
+tar -czf "${OUTDIR}/llama-${TAG}-bin-ubuntu-rocm-${ROCM_SERIES}-x64.tar.gz" bin lib
+ls -lh "${OUTDIR}/llama-${TAG}-bin-ubuntu-rocm-${ROCM_SERIES}-x64.tar.gz"

--- a/scripts/llama-build/common.sh
+++ b/scripts/llama-build/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared helpers for Ubuntu 22.04 CUDA llama.cpp mirror builds.
+# Shared helpers for Ubuntu 22.04 CUDA and ROCm llama.cpp mirror builds.
 set -euo pipefail
 
 LLAMA_BUILD_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -7,6 +7,12 @@ LLAMA_BUILD_REPO_ROOT="$(cd "${LLAMA_BUILD_SCRIPT_DIR}/../.." && pwd)"
 LLAMA_BUILD_WORK_DIR="${LLAMA_BUILD_WORK_DIR:-${LLAMA_BUILD_SCRIPT_DIR}/work}"
 LLAMA_BUILD_OUT_DIR="${LLAMA_BUILD_OUT_DIR:-${LLAMA_BUILD_WORK_DIR}/out}"
 LLAMA_BUILD_CUDA_IMAGE="${LLAMA_BUILD_CUDA_IMAGE:-nvidia/cuda:12.9.1-devel-ubuntu22.04}"
+# Must stay on the same ROCm series and Ubuntu base as docker/rocm/Dockerfile's
+# runtime image, otherwise the package cannot load there.
+LLAMA_BUILD_ROCM_IMAGE="${LLAMA_BUILD_ROCM_IMAGE:-rocm/dev-ubuntu-22.04:7.2.2-complete}"
+LLAMA_BUILD_ROCM_SERIES="${LLAMA_BUILD_ROCM_SERIES:-7.2}"
+# Plain 22.04 userland, used to prove a package does not need GLIBC_2.38.
+LLAMA_BUILD_UBUNTU_IMAGE="${LLAMA_BUILD_UBUNTU_IMAGE:-ubuntu:22.04}"
 LLAMA_BUILD_GITLAB_PROJECT_ID="${LLAMA_BUILD_GITLAB_PROJECT_ID:-393}"
 LLAMA_BUILD_GITLAB_API="${LLAMA_BUILD_GITLAB_API:-https://git-devops.opencsg.com/api/v4}"
 
@@ -21,14 +27,34 @@ llama_build_ensure_docker() {
   fi
 }
 
-llama_build_ensure_cuda_image() {
-  local platform="$1"
-  if docker image inspect --platform "${platform}" "${LLAMA_BUILD_CUDA_IMAGE}" >/dev/null 2>&1; then
-    echo "Reusing local ${LLAMA_BUILD_CUDA_IMAGE} (${platform})"
+llama_build_ensure_image() {
+  local image="$1"
+  local platform="$2"
+  if docker image inspect --platform "${platform}" "${image}" >/dev/null 2>&1; then
+    echo "Reusing local ${image} (${platform})"
     return 0
   fi
-  echo "Pulling ${LLAMA_BUILD_CUDA_IMAGE} (${platform})..."
-  docker pull --platform "${platform}" "${LLAMA_BUILD_CUDA_IMAGE}"
+  echo "Pulling ${image} (${platform})..."
+  docker pull --platform "${platform}" "${image}"
+}
+
+llama_build_ensure_cuda_image() {
+  llama_build_ensure_image "${LLAMA_BUILD_CUDA_IMAGE}" "$1"
+}
+
+llama_build_ensure_rocm_image() {
+  llama_build_ensure_image "${LLAMA_BUILD_ROCM_IMAGE}" "$1"
+}
+
+# amd64 builds run under QEMU on Apple Silicon. A CUDA build is merely slow
+# there; a multi-target ROCm build is slow enough to be worth calling out.
+llama_build_warn_emulated_amd64() {
+  local platform="$1"
+  if [ "${platform}" = "linux/amd64" ] && [ "$(uname -m)" = "arm64" ]; then
+    echo "WARNING: building linux/amd64 on an arm64 host runs under QEMU emulation."
+    echo "         Expect a very long build. Prefer an x86_64 Linux builder,"
+    echo "         or narrow GPU_TARGETS to the gfx architectures you actually ship."
+  fi
 }
 
 llama_build_clone_source() {

--- a/scripts/llama-build/compare-with-gitlab.sh
+++ b/scripts/llama-build/compare-with-gitlab.sh
@@ -6,9 +6,10 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=common.sh
 source "${ROOT}/common.sh"
 
-ARCH="${1:?arch: x64 or arm64}"
+ARCH="${1:?arch: x64, arm64 or rocm-x64}"
 TAG="$(llama_build_tag "${2:-}")"
 OUT="${LLAMA_BUILD_OUT_DIR}"
+IMAGE="${LLAMA_BUILD_CUDA_IMAGE}"
 
 case "${ARCH}" in
   x64)
@@ -19,8 +20,13 @@ case "${ARCH}" in
     PLATFORM=linux/arm64
     TAR="llama-${TAG}-bin-ubuntu-cuda-arm64.tar.gz"
   ;;
+  rocm-x64)
+    PLATFORM=linux/amd64
+    TAR="llama-${TAG}-bin-ubuntu-rocm-${LLAMA_BUILD_ROCM_SERIES}-x64.tar.gz"
+    IMAGE="${LLAMA_BUILD_ROCM_IMAGE}"
+  ;;
   *)
-    echo "usage: $0 x64|arm64 [tag]" >&2
+    echo "usage: $0 x64|arm64|rocm-x64 [tag]" >&2
     exit 1
   ;;
 esac
@@ -50,12 +56,12 @@ diff -u \
   <(cd "${WORKDIR}/new" && find . \( -type f -o -type l \) | sed 's|^\./||' | LC_ALL=C sort) || true
 
 llama_build_ensure_docker
-llama_build_ensure_cuda_image "${PLATFORM}"
+llama_build_ensure_image "${IMAGE}" "${PLATFORM}"
 
 echo "=== ref version (Ubuntu 22.04) ==="
 docker run --platform "${PLATFORM}" --pull=never --rm \
   -v "${REF}:/pkg.tar.gz:ro" \
-  "${LLAMA_BUILD_CUDA_IMAGE}" bash -lc \
+  "${IMAGE}" bash -lc \
   'mkdir -p /tmp/p && tar -xzf /pkg.tar.gz -C /tmp/p
     server=$(find /tmp/p -type f -path "*/bin/llama-server" -print -quit)
     r=${server%/bin/llama-server}
@@ -64,7 +70,7 @@ docker run --platform "${PLATFORM}" --pull=never --rm \
 echo "=== new version (Ubuntu 22.04) ==="
 docker run --platform "${PLATFORM}" --pull=never --rm \
   -v "${NEW}:/pkg.tar.gz:ro" \
-  "${LLAMA_BUILD_CUDA_IMAGE}" bash -lc \
+  "${IMAGE}" bash -lc \
   'mkdir -p /tmp/p && tar -xzf /pkg.tar.gz -C /tmp/p
     server=$(find /tmp/p -type f -path "*/bin/llama-server" -print -quit)
     r=${server%/bin/llama-server}

--- a/scripts/llama-build/rebuild-upload-rocm-x64.sh
+++ b/scripts/llama-build/rebuild-upload-rocm-x64.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Rebuild the Ubuntu 22.04 ROCm x64 tarball and upload it to GitLab generic packages.
+#
+# Set LLAMA_BUILD_SKIP_UPLOAD=1 to build and verify without publishing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=common.sh
+source "${ROOT}/common.sh"
+
+TAG="$(llama_build_tag "${1:-}")"
+ROCM_SERIES="${LLAMA_BUILD_ROCM_SERIES}"
+PLATFORM=linux/amd64
+SRC="${LLAMA_BUILD_WORK_DIR}/src-rocm-amd64/llama.cpp"
+OUT="${LLAMA_BUILD_OUT_DIR}"
+TAR="llama-${TAG}-bin-ubuntu-rocm-${ROCM_SERIES}-x64.tar.gz"
+
+llama_build_ensure_docker
+llama_build_warn_emulated_amd64 "${PLATFORM}"
+llama_build_ensure_rocm_image "${PLATFORM}"
+llama_build_ensure_image "${LLAMA_BUILD_UBUNTU_IMAGE}" "${PLATFORM}"
+llama_build_clone_source "${SRC}" "${TAG}"
+
+rm -rf "${SRC}/build" "${OUT}/stage" "${OUT}/${TAR}"
+mkdir -p "${OUT}"
+
+docker run --platform "${PLATFORM}" --pull=never --rm \
+  -v "${SRC}:/work/llama.cpp" \
+  -v "${ROOT}/build-ubuntu22-rocm-x64.sh:/build.sh:ro" \
+  -v "${OUT}:/out" \
+  -e WORKDIR=/work \
+  -e OUTDIR=/out \
+  -e LLAMA_TAG="${TAG}" \
+  -e ROCM_SERIES="${ROCM_SERIES}" \
+  ${GPU_TARGETS:+-e GPU_TARGETS="${GPU_TARGETS}"} \
+  "${LLAMA_BUILD_ROCM_IMAGE}" \
+  bash /build.sh
+
+# Regression guard for the failure this package exists to avoid: a plain 22.04
+# userland must be able to load every packaged object. libamdhip64/librocblas
+# are legitimately absent here; a GLIBC/GLIBCXX version error is not.
+echo "=== verify glibc baseline on plain ${LLAMA_BUILD_UBUNTU_IMAGE} (${PLATFORM}) ==="
+docker run --platform "${PLATFORM}" --pull=never --rm \
+  -v "${OUT}/${TAR}:/pkg.tar.gz:ro" \
+  "${LLAMA_BUILD_UBUNTU_IMAGE}" bash -lc '
+    set -eu
+    mkdir -p /tmp/p && tar -xzf /pkg.tar.gz -C /tmp/p
+    bad=0
+    for f in /tmp/p/bin/llama-server /tmp/p/lib/*.so*; do
+      [ -f "$f" ] || continue
+      out=$(LD_LIBRARY_PATH=/tmp/p/lib ldd "$f" 2>&1 || true)
+      if printf "%s\n" "$out" | grep -q "version .GLIBC\|version .GLIBCXX"; then
+        echo "GLIBC/GLIBCXX too new in $(basename "$f"):"
+        printf "%s\n" "$out" | grep "version .GLIBC\|version .GLIBCXX"
+        bad=1
+      fi
+    done
+    [ "$bad" -eq 0 ] || exit 1
+    echo "OK: no GLIBC/GLIBCXX version errors on 22.04"
+  '
+
+echo "=== verify llama-server --version in ${LLAMA_BUILD_ROCM_IMAGE} (${PLATFORM}) ==="
+docker run --platform "${PLATFORM}" --pull=never --rm \
+  -v "${OUT}/${TAR}:/pkg.tar.gz:ro" \
+  "${LLAMA_BUILD_ROCM_IMAGE}" bash -lc \
+  'mkdir -p /tmp/p && tar -xzf /pkg.tar.gz -C /tmp/p
+   LD_LIBRARY_PATH=/tmp/p/lib:/opt/rocm/lib /tmp/p/bin/llama-server --version' || \
+  echo "WARN: --version exited non-zero; no /dev/kfd in this container. Validate on an AMD GPU host."
+
+if [ "${LLAMA_BUILD_SKIP_UPLOAD:-0}" = "1" ]; then
+  echo "LLAMA_BUILD_SKIP_UPLOAD=1, not uploading. Artifact: ${OUT}/${TAR}"
+  shasum -a 256 "${OUT}/${TAR}"
+  exit 0
+fi
+
+llama_build_upload_tarball "${TAG}" "${OUT}/${TAR}"


### PR DESCRIPTION
Upstream started publishing llama-<tag>-bin-ubuntu-rocm-<series>-x64.tar.gz at b10830, but builds that job on ubuntu-24.04. On a 22.04 ROCm host the installer picked it up and llama-server failed with `GLIBC_2.38 not found` and `GLIBCXX_3.4.32 not found`. b10549 had no Linux ROCm asset at all, so the same host silently fell through to a CPU/Vulkan package and worked.

ROCm now follows the same local-build policy as Ubuntu CUDA:

- build-ubuntu22-rocm-x64.sh compiles inside rocm/dev-ubuntu-22.04:7.2.2-complete with GGML_HIP=ON, HIP_PLATFORM=amd and CMAKE_HIP_COMPILER from hipconfig. It pins CMake 3.31.6: the HIP language needs >= 3.21, but CMake 4 removed cmake_minimum_required(<3.5) support that ROCm config packages still declare.
- GPU_TARGETS defaults to the gfx coverage of the last mirrored ROCm package (b9158, rocm-7.2) and is overridable for single-card builds.
- rebuild-upload-rocm-x64.sh verifies in a plain ubuntu:22.04 container that no packaged object reports a GLIBC/GLIBCXX version error before uploading, which is a direct regression check for the failure above. LLAMA_BUILD_SKIP_UPLOAD=1 builds without publishing.
- common.sh gains ROCm/Ubuntu image settings and a generic ensure_image; ensure_cuda_image stays as a wrapper. compare-with-gitlab.sh accepts rocm-x64.
- make llama-rocm-rebuild-x64 runs it. Deliberately not part of rebuild-upload-all.sh: it is amd64 only and far more expensive than CUDA.

Docs record that upstream ubuntu-rocm assets must not be mirrored, and that the ROCm series in the filename must track docker/rocm/Dockerfile, since install.sh falls back to any published ROCm asset when the series-specific one is missing.

Generated with AI