### PR TITLE
fix(asr): prefer newest compatible host Python and rebuild stale venvs

### DIFF
--- a/internal/imagegen/runtime.go
+++ b/internal/imagegen/runtime.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -243,6 +244,116 @@ func (m *RuntimeManager) uvPath() string {
 	return filepath.Join(m.VenvDir(), "bin", "uv")
 }
 
+// checkVenvPython validates that the venv exists and that its interpreter is
+// still usable. It returns a description of what needs to happen:
+//   - recreate=true  the venv is missing, unusable, or pinned to a Python
+//     older than the runtime requires, so it must be (re)created from a host
+//     interpreter;
+//   - recreate=false and hostPython!="" the venv works but is older than the
+//     best host interpreter found; recreating it picks up the newer Python.
+func (m *RuntimeManager) checkVenvPython(ctx context.Context) (recreate bool, hostPython string, err error) {
+	python := m.PythonPath()
+	if _, statErr := os.Stat(python); statErr != nil {
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return false, "", fmt.Errorf("checking runtime venv python: %w", statErr)
+		}
+		host, hostErr := findHostPython()
+		if hostErr != nil {
+			return false, "", hostErr
+		}
+		return true, host, nil
+	}
+	venvVersion, probeErr := probePythonVersionAt(ctx, python)
+	if probeErr == nil && hostPythonSupported(venvVersion) {
+		host, hostErr := findHostPython()
+		if hostErr != nil {
+			// The existing venv is fine; keep using it even when no better
+			// host interpreter can be detected right now.
+			return false, "", nil
+		}
+		return false, host, nil
+	}
+	// Broken interpreter (e.g. venv pointing at a removed framework) or a
+	// Python older than the supported range: rebuild it on a fresh host.
+	// Include what is wrong with the venv so the error is actionable.
+	venvProblem := fmt.Sprintf("existing runtime venv %s", python)
+	switch {
+	case probeErr != nil:
+		venvProblem = fmt.Sprintf("existing runtime venv python %s is not runnable: %v", python, probeErr)
+	case venvVersion != "":
+		venvProblem = fmt.Sprintf("existing runtime venv %s uses Python %s", python, venvVersion)
+	}
+	host, hostErr := findHostPython()
+	if hostErr != nil {
+		return false, "", fmt.Errorf("%s; no suitable host Python was found: %w", venvProblem, hostErr)
+	}
+	return true, host, nil
+}
+
+// ensureVenvForInstall recreates the runtime venv when it is missing,
+// unusable, or pinned to a Python older than the runtime requires. A healthy
+// venv is kept as-is: an upgrade to a newer host Python only happens when the
+// caller explicitly asks for one (upgradePackages), because rebuilding it
+// forces a full torch/funasr reinstall and can regress a working install.
+func (m *RuntimeManager) ensureVenvForInstall(ctx context.Context, progress ProgressFunc, step, total int, upgradePackages bool) error {
+	recreate, hostPython, err := m.checkVenvPython(ctx)
+	if err != nil {
+		return err
+	}
+	if !recreate {
+		if upgradePackages && hostPython != "" && m.venvIsOlderThan(ctx, hostPython) {
+			progress("upgrade runtime venv to newer Python", step, total)
+			if err := m.recreateVenv(ctx, hostPython); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if m.venvExists() {
+		progress("remove outdated runtime venv", step, total)
+		if err := os.RemoveAll(m.VenvDir()); err != nil {
+			return fmt.Errorf("removing outdated runtime venv: %w", err)
+		}
+	}
+	progress("create Python venv", step, total)
+	if err := runCommand(ctx, hostPython, "-m", "venv", m.VenvDir()); err != nil {
+		return fmt.Errorf("creating Python venv: %w", err)
+	}
+	return nil
+}
+
+func (m *RuntimeManager) recreateVenv(ctx context.Context, hostPython string) error {
+	if err := os.RemoveAll(m.VenvDir()); err != nil {
+		return fmt.Errorf("removing outdated runtime venv: %w", err)
+	}
+	if err := runCommand(ctx, hostPython, "-m", "venv", m.VenvDir()); err != nil {
+		return fmt.Errorf("creating Python venv: %w", err)
+	}
+	return nil
+}
+
+func (m *RuntimeManager) venvExists() bool {
+	_, err := os.Stat(m.PythonPath())
+	return err == nil
+}
+
+func (m *RuntimeManager) venvIsOlderThan(ctx context.Context, hostPython string) bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	venvVersion, err := probePythonVersionAt(ctx, m.PythonPath())
+	if err != nil {
+		return false
+	}
+	hostVersion, err := probePythonVersionAt(ctx, hostPython)
+	if err != nil {
+		return false
+	}
+	venvMinor, venvOK := parsePythonMinor(venvVersion)
+	hostMinor, hostOK := parsePythonMinor(hostVersion)
+	return venvOK && hostOK && hostMinor > venvMinor
+}
+
 func (m *RuntimeManager) Status(ctx context.Context) RuntimeStatus {
 	hardware := DetectHardware()
 	indexes := ResolvePackageIndexes(hardware)
@@ -414,15 +525,8 @@ func (m *RuntimeManager) InstallWithProgressOptions(ctx context.Context, progres
 	if err := os.MkdirAll(m.rootDir, 0o755); err != nil {
 		return m.Status(ctx), fmt.Errorf("creating image runtime directory: %w", err)
 	}
-	if _, err := os.Stat(m.PythonPath()); err != nil {
-		hostPython, err := findHostPython()
-		if err != nil {
-			return m.Status(ctx), err
-		}
-		progress("create Python venv", 3, 6)
-		if err := runCommand(ctx, hostPython, "-m", "venv", m.VenvDir()); err != nil {
-			return m.Status(ctx), fmt.Errorf("creating Python venv: %w", err)
-		}
+	if err := m.ensureVenvForInstall(ctx, progress, 3, 6, upgradePackages); err != nil {
+		return m.Status(ctx), err
 	}
 
 	python := m.PythonPath()
@@ -492,19 +596,11 @@ func (m *RuntimeManager) InstallASRWithProgressOptions(ctx context.Context, prog
 	if err := os.MkdirAll(m.rootDir, 0o755); err != nil {
 		return m.ASRStatus(ctx), fmt.Errorf("creating runtime directory: %w", err)
 	}
-
-	python := m.PythonPath()
-	if _, err := os.Stat(python); err != nil {
-		hostPython, err := findHostPython()
-		if err != nil {
-			return m.ASRStatus(ctx), err
-		}
-		progress("create Python venv", 3, 5)
-		if err := runCommand(ctx, hostPython, "-m", "venv", m.VenvDir()); err != nil {
-			return m.ASRStatus(ctx), fmt.Errorf("creating Python venv: %w", err)
-		}
+	if err := m.ensureVenvForInstall(ctx, progress, 3, 5, upgradePackages); err != nil {
+		return m.ASRStatus(ctx), err
 	}
 
+	python := m.PythonPath()
 	torchMissing, err := missingPackages(ctx, python, []string{"torch", "torchaudio"})
 	if err != nil {
 		return m.ASRStatus(ctx), err
@@ -593,19 +689,11 @@ func (m *RuntimeManager) InstallEmbeddingWithProgressOptions(ctx context.Context
 	if err := os.MkdirAll(m.rootDir, 0o755); err != nil {
 		return m.EmbeddingStatus(ctx), fmt.Errorf("creating runtime directory: %w", err)
 	}
-
-	python := m.PythonPath()
-	if _, err := os.Stat(python); err != nil {
-		hostPython, err := findHostPython()
-		if err != nil {
-			return m.EmbeddingStatus(ctx), err
-		}
-		progress("create Python venv", 3, 5)
-		if err := runCommand(ctx, hostPython, "-m", "venv", m.VenvDir()); err != nil {
-			return m.EmbeddingStatus(ctx), fmt.Errorf("creating Python venv: %w", err)
-		}
+	if err := m.ensureVenvForInstall(ctx, progress, 3, 5, upgradePackages); err != nil {
+		return m.EmbeddingStatus(ctx), err
 	}
 
+	python := m.PythonPath()
 	torchMissing, err := missingPackages(ctx, python, []string{"torch"})
 	if err != nil {
 		return m.EmbeddingStatus(ctx), err
@@ -924,18 +1012,174 @@ func isChinaLocale() bool {
 	return false
 }
 
+// minimumHostPythonMinor is the lowest minor version accepted for host
+// Python interpreters. qwen-asr pins accelerate versions that require
+// Python>=3.10, so anything older cannot run the full ASR stack.
+const minimumHostPythonMinor = 10
+
+// maxHostPythonMinor is the newest minor version accepted for host Python
+// interpreters. The ASR stack (torch, funasr, qwen-asr) is verified to
+// install and run on this range; pre-release Pythons stay out.
+const maxHostPythonMinor = 14
+
+// pythonVersionRangeHint mirrors the supported range in user-facing errors.
+const pythonVersionRangeHint = "Python 3.10-3.14"
+
+// hostPythonEnv lets users point the runtime at a specific interpreter,
+// which is also the escape hatch when automatic detection picks wrong.
+const hostPythonEnv = "CSGHUB_LITE_HOST_PYTHON"
+
+// candidateHostPythons lists interpreters from newest to oldest so a
+// machine with several Pythons gets the newest compatible one, falling
+// back to older Pythons (including the macOS system 3.9) only when no
+// newer interpreter exists.
+func candidateHostPythons() []string {
+	versioned := make([]string, 0, maxHostPythonMinor-minimumHostPythonMinor+1)
+	for minor := maxHostPythonMinor; minor >= minimumHostPythonMinor; minor-- {
+		versioned = append(versioned, fmt.Sprintf("python3.%d", minor))
+	}
+	return append(versioned, "python3", "python")
+}
+
+// wellKnownHostPythonPaths lists absolute interpreter locations that GUI
+// processes may not see on PATH. Desktop csghub-lite is launched by
+// Finder/launchd with a minimal PATH (/usr/bin:/bin:...), so Homebrew,
+// python.org, MacPorts, pyenv, and user-level installs are invisible to
+// exec.LookPath even though the user installed them. Like internal/convert,
+// probe these well-known locations as a fallback, newest to oldest.
+func wellKnownHostPythonPaths() []string {
+	userLocal := func(sub ...string) string {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return ""
+		}
+		return filepath.Join(append([]string{home, ".local", "bin"}, sub...)...)
+	}
+	pyenvShims := func(sub ...string) string {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return ""
+		}
+		return filepath.Join(append([]string{home, ".pyenv", "shims"}, sub...)...)
+	}
+
+	var paths []string
+	switch runtime.GOOS {
+	case "darwin":
+		for minor := maxHostPythonMinor; minor >= minimumHostPythonMinor; minor-- {
+			v := fmt.Sprintf("3.%d", minor)
+			paths = append(paths,
+				fmt.Sprintf("/opt/homebrew/bin/python%s", v),
+				fmt.Sprintf("/usr/local/bin/python%s", v),
+				fmt.Sprintf("/Library/Frameworks/Python.framework/Versions/%s/bin/python%s", v, v),
+				fmt.Sprintf("/opt/local/bin/python%s", v),
+			)
+		}
+		paths = append(paths, "/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/opt/local/bin/python3")
+	case "linux":
+		for minor := maxHostPythonMinor; minor >= minimumHostPythonMinor; minor-- {
+			v := fmt.Sprintf("3.%d", minor)
+			paths = append(paths,
+				fmt.Sprintf("/usr/local/bin/python%s", v),
+				fmt.Sprintf("/usr/bin/python%s", v),
+				fmt.Sprintf("/snap/bin/python%s", v),
+			)
+		}
+		paths = append(paths, "/usr/local/bin/python3", "/usr/bin/python3", "/snap/bin/python3")
+	}
+	for _, fancy := range []func(...string) string{userLocal, pyenvShims} {
+		for minor := maxHostPythonMinor; minor >= minimumHostPythonMinor; minor-- {
+			if p := fancy(fmt.Sprintf("python3.%d", minor)); p != "" {
+				paths = append(paths, p)
+			}
+		}
+		if p := fancy("python3"); p != "" {
+			paths = append(paths, p)
+		}
+		if p := fancy("python"); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+func hostPythonSupported(version string) bool {
+	minor, ok := parsePythonMinor(version)
+	return ok && minor >= minimumHostPythonMinor && minor <= maxHostPythonMinor
+}
+
+func parsePythonMinor(version string) (int, bool) {
+	parts := strings.SplitN(strings.TrimSpace(version), ".", 3)
+	if len(parts) < 2 || parts[0] != "3" {
+		return 0, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, false
+	}
+	return minor, true
+}
+
 func findHostPython() (string, error) {
+	return findHostPythonWithContext(context.Background())
+}
+
+func findHostPythonWithContext(ctx context.Context) (string, error) {
+	if path := strings.TrimSpace(os.Getenv(hostPythonEnv)); path != "" {
+		version, err := probePythonVersionAt(ctx, path)
+		if err != nil {
+			return "", fmt.Errorf("%s=%s 不是可用的 Python 解释器", hostPythonEnv, path)
+		}
+		if !hostPythonSupported(version) {
+			return "", fmt.Errorf("%s=%s 是 Python %s，请使用 %s", hostPythonEnv, path, version, pythonVersionRangeHint)
+		}
+		log.Printf("PYTHON: selected host interpreter path=%s version=%s source=%s", path, version, hostPythonEnv)
+		return path, nil
+	}
 	if runtime.GOOS == "windows" {
 		return findWindowsHostPython()
 	}
-	candidates := []string{"python3", "python"}
-	for _, candidate := range candidates {
-		if path, err := exec.LookPath(candidate); err == nil {
-			log.Printf("PYTHON: selected host interpreter path=%s", path)
-			return path, nil
+	return findHostPythonFrom(ctx, candidateHostPythons(), wellKnownHostPythonPaths())
+}
+
+// findHostPythonFrom scans explicit candidate lists; split out so tests can
+// inject fake interpreter locations instead of depending on what the host
+// machine happens to have installed.
+func findHostPythonFrom(ctx context.Context, pathCandidates, wellKnownPaths []string) (string, error) {
+	var lastUnsupported string
+	var found string
+	scan := func(path string) bool {
+		if path == "" {
+			return false
+		}
+		version, err := probePythonVersionAt(ctx, path)
+		if err != nil {
+			return false
+		}
+		if hostPythonSupported(version) {
+			log.Printf("PYTHON: selected host interpreter path=%s version=%s", path, version)
+			found = path
+			return true
+		}
+		if lastUnsupported == "" {
+			lastUnsupported = fmt.Sprintf("%s (Python %s)", path, version)
+		}
+		return false
+	}
+	for _, candidate := range pathCandidates {
+		if path, err := exec.LookPath(candidate); err == nil && scan(path) {
+			return found, nil
 		}
 	}
-	return "", errors.New("Python 3.10, 3.11, or 3.12 is required to install the Diffusers runtime")
+	for _, path := range wellKnownPaths {
+		if _, err := os.Stat(path); err == nil && scan(path) {
+			return found, nil
+		}
+	}
+	if lastUnsupported != "" {
+		return "", fmt.Errorf("检测到 %s，AI 运行时需要 %s，请安装后重试", lastUnsupported, pythonVersionRangeHint)
+	}
+	return "", errors.New("未找到可用的 Python 解释器，AI 运行时需要 " + pythonVersionRangeHint)
 }
 
 func findWindowsHostPython() (string, error) {
@@ -943,6 +1187,8 @@ func findWindowsHostPython() (string, error) {
 		name string
 		args []string
 	}{
+		{name: "py", args: []string{"-3.14"}},
+		{name: "py", args: []string{"-3.13"}},
 		{name: "py", args: []string{"-3.12"}},
 		{name: "py", args: []string{"-3.11"}},
 		{name: "py", args: []string{"-3.10"}},
@@ -960,15 +1206,15 @@ func findWindowsHostPython() (string, error) {
 		if detectedVersion == "" {
 			detectedVersion = version
 		}
-		if windowsPythonVersionSupported(version) {
+		if hostPythonSupported(version) {
 			log.Printf("PYTHON: selected host interpreter path=%s version=%s", path, version)
 			return path, nil
 		}
 	}
 	if detectedVersion != "" {
-		return "", fmt.Errorf("检测到 Python %s，其 Windows wheel 生态尚不完整，请安装 Python 3.10-3.12", detectedVersion)
+		return "", fmt.Errorf("检测到 Python %s，其 Windows wheel 生态尚不完整，请安装 Python %s", detectedVersion, pythonVersionRangeHint)
 	}
-	return "", errors.New("Python 3.10, 3.11, or 3.12 is required to install the Diffusers runtime")
+	return "", errors.New(pythonVersionRangeHint + " is required to install the Diffusers runtime")
 }
 
 func probePython(name string, args ...string) (string, string, error) {
@@ -985,13 +1231,24 @@ func probePython(name string, args ...string) (string, string, error) {
 	return strings.TrimSpace(lines[0]), strings.TrimSpace(lines[1]), nil
 }
 
-func windowsPythonVersionSupported(version string) bool {
-	switch version {
-	case "3.10", "3.11", "3.12":
-		return true
-	default:
-		return false
+// probePythonVersionAt reports the version of a specific interpreter path.
+func probePythonVersionAt(ctx context.Context, path string) (string, error) {
+	_, version, err := probePythonWithContext(ctx, path)
+	return version, err
+}
+
+func probePythonWithContext(ctx context.Context, name string, args ...string) (string, string, error) {
+	script := "import sys\nprint(sys.executable)\nprint(f'{sys.version_info[0]}.{sys.version_info[1]}')\n"
+	cmdArgs := append(append([]string{}, args...), "-c", script)
+	out, err := exec.CommandContext(ctx, name, cmdArgs...).Output()
+	if err != nil {
+		return "", "", err
 	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return "", "", fmt.Errorf("unexpected Python probe output: %q", strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(lines[0]), strings.TrimSpace(lines[1]), nil
 }
 
 func missingPackages(ctx context.Context, python string, packages []string) ([]string, error) {

--- a/internal/imagegen/runtime_test.go
+++ b/internal/imagegen/runtime_test.go
@@ -2,6 +2,7 @@ package imagegen
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -400,6 +401,365 @@ exit 0
 	}
 	if _, err := os.Stat(marker); err == nil {
 		t.Fatal("missing torchaudio should be a no-op")
+	}
+}
+
+func TestCandidateHostPythonsOrderNewestFirst(t *testing.T) {
+	candidates := candidateHostPythons()
+	wantHead := []string{"python3.14", "python3.13", "python3.12", "python3.11", "python3.10"}
+	if len(candidates) < len(wantHead)+2 {
+		t.Fatalf("candidateHostPythons() too short: %#v", candidates)
+	}
+	for i, want := range wantHead {
+		if candidates[i] != want {
+			t.Fatalf("candidateHostPythons()[%d] = %q, want %q (full: %#v)", i, candidates[i], want, candidates)
+		}
+	}
+	if tail := candidates[len(candidates)-2:]; tail[0] != "python3" || tail[1] != "python" {
+		t.Fatalf("candidateHostPythons() should end with python3, python: %#v", candidates)
+	}
+}
+
+func TestParsePythonMinorAndSupport(t *testing.T) {
+	tests := []struct {
+		version   string
+		minor     int
+		ok        bool
+		supported bool
+	}{
+		{"3.9.6", 9, true, false},
+		{"3.10.0", 10, true, true},
+		{"3.11", 11, true, true},
+		{"3.13.7", 13, true, true},
+		{"3.14.7", 14, true, true},
+		{"3.15.0", 15, true, false},
+		{"2.7.18", 0, false, false},
+		{"garbage", 0, false, false},
+	}
+	for _, tt := range tests {
+		minor, ok := parsePythonMinor(tt.version)
+		if ok != tt.ok || (ok && minor != tt.minor) {
+			t.Fatalf("parsePythonMinor(%q) = (%d, %v), want (%d, %v)", tt.version, minor, ok, tt.minor, tt.ok)
+		}
+		if got := hostPythonSupported(tt.version); got != tt.supported {
+			t.Fatalf("hostPythonSupported(%q) = %v, want %v", tt.version, got, tt.supported)
+		}
+	}
+}
+
+// findHostPython must prefer the newest versioned interpreter on PATH even
+// when the unversioned python3/python names resolve to something older, and
+// must never pick an interpreter outside the supported range.
+func TestFindHostPythonPrefersVersionedInterpreters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	writeFakePythonAt(t, filepath.Join(dir, "python3.13"), probeScriptOutput("3.13.1"))
+	writeFakePythonAt(t, filepath.Join(dir, "python3.11"), probeScriptOutput("3.11.9"))
+	writeFakePythonAt(t, filepath.Join(dir, "python3"), probeScriptOutput("3.9.6"))
+	writeFakePythonAt(t, filepath.Join(dir, "python"), probeScriptOutput("3.9.6"))
+
+	path, err := findHostPythonFrom(context.Background(), candidateHostPythons(), nil)
+	if err != nil {
+		t.Fatalf("findHostPython error = %v", err)
+	}
+	if path != filepath.Join(dir, "python3.13") {
+		t.Fatalf("findHostPython = %q, want newest versioned interpreter %q", path, filepath.Join(dir, "python3.13"))
+	}
+}
+
+func TestFindHostPythonFallsBackToOlderVersionedInterpreter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	writeFakePythonAt(t, filepath.Join(dir, "python3.11"), probeScriptOutput("3.11.9"))
+	writeFakePythonAt(t, filepath.Join(dir, "python3"), probeScriptOutput("3.9.6"))
+	writeFakePythonAt(t, filepath.Join(dir, "python"), probeScriptOutput("3.9.6"))
+
+	path, err := findHostPythonFrom(context.Background(), candidateHostPythons(), nil)
+	if err != nil {
+		t.Fatalf("findHostPython error = %v", err)
+	}
+	if path != filepath.Join(dir, "python3.11") {
+		t.Fatalf("findHostPython = %q, want %q", path, filepath.Join(dir, "python3.11"))
+	}
+}
+
+func TestFindHostPythonRejectsOnlyUnsupportedPythons(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	writeFakePythonAt(t, filepath.Join(dir, "python3"), probeScriptOutput("3.9.6"))
+	writeFakePythonAt(t, filepath.Join(dir, "python"), probeScriptOutput("3.9.6"))
+
+	if path, err := findHostPythonFrom(context.Background(), candidateHostPythons(), nil); err == nil {
+		t.Fatalf("findHostPython = %q with only 3.9 on PATH, want error", path)
+	}
+}
+
+// findHostPython must fall back to well-known absolute interpreter
+// locations when PATH is minimal (GUI apps get /usr/bin:/bin:... from
+// launchd and never see Homebrew or python.org installs). The lists are
+// injected so the test never touches real interpreter locations.
+func TestFindHostPythonFallsBackToWellKnownPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses absolute unix paths")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir) // minimal PATH without any python
+
+	wellKnown := filepath.Join(dir, "well-known", "python3.11")
+	writeFakePythonAt(t, wellKnown, probeScriptOutput("3.11.9"))
+
+	path, err := findHostPythonFrom(context.Background(), candidateHostPythons(), []string{wellKnown})
+	if err != nil {
+		t.Fatalf("findHostPython error = %v", err)
+	}
+	if path != wellKnown {
+		t.Fatalf("findHostPython = %q, want well-known path %q", path, wellKnown)
+	}
+
+	// A well-known path that fails the probe is skipped, not fatal.
+	writeFakePythonAt(t, wellKnown, "exit 1\n")
+	if path, err := findHostPythonFrom(context.Background(), candidateHostPythons(), []string{wellKnown, filepath.Join(dir, "well-known", "python3.12")}); err == nil {
+		t.Fatalf("findHostPython = %q with broken well-known python, want error", path)
+	}
+}
+
+func TestWellKnownHostPythonPathsSkipUnsupportedVersions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generates unix absolute paths")
+	}
+	paths := wellKnownHostPythonPaths()
+	if len(paths) == 0 {
+		t.Fatalf("wellKnownHostPythonPaths() empty on %s", runtime.GOOS)
+	}
+	for _, p := range paths {
+		if strings.Contains(p, fmt.Sprintf("python3.%d", minimumHostPythonMinor-1)) {
+			t.Fatalf("well-known paths must stay within the supported range: %q", p)
+		}
+	}
+	// Newest first.
+	if !strings.Contains(paths[0], fmt.Sprintf("python3.%d", maxHostPythonMinor)) {
+		t.Fatalf("first well-known path = %q, want newest minor %d", paths[0], maxHostPythonMinor)
+	}
+}
+
+func TestFindHostPythonHonorsOverrideEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	python := filepath.Join(dir, "custom-python")
+	writeFakePythonAt(t, python, probeScriptOutput("3.12.4"))
+	t.Setenv(hostPythonEnv, python)
+
+	path, err := findHostPython()
+	if err != nil {
+		t.Fatalf("findHostPython error = %v", err)
+	}
+	if path != python {
+		t.Fatalf("findHostPython = %q, want override %q", path, python)
+	}
+
+	writeFakePythonAt(t, python, probeScriptOutput("3.9.6"))
+	if path, err := findHostPython(); err == nil {
+		t.Fatalf("findHostPython = %q with unsupported override version, want error", path)
+	}
+
+	t.Setenv(hostPythonEnv, filepath.Join(dir, "missing-python"))
+	if path, err := findHostPython(); err == nil {
+		t.Fatalf("findHostPython = %q with missing override path, want error", path)
+	}
+}
+
+// probeScriptOutput builds a fake python body mimicking the real probe in
+// probePython: it prints sys.executable and the interpreter version.
+func probeScriptOutput(version string) string {
+	return fmt.Sprintf("printf '%%s\\n%%s\\n' \"$0\" %q\n", version)
+}
+
+func TestCheckVenvPythonMissingVenvUsesNewestHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	writeFakePythonAt(t, filepath.Join(dir, "python3.11"), probeScriptOutput("3.11.9"))
+
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	recreate, hostPython, err := m.checkVenvPython(context.Background())
+	if err != nil {
+		t.Fatalf("checkVenvPython error = %v", err)
+	}
+	if !recreate {
+		t.Fatal("missing venv should request recreation")
+	}
+	if hostPython != filepath.Join(dir, "python3.11") {
+		t.Fatalf("hostPython = %q, want %q", hostPython, filepath.Join(dir, "python3.11"))
+	}
+}
+
+func TestCheckVenvPythonKeepsFreshVenv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	writeFakePythonAt(t, filepath.Join(dir, "python3.11"), probeScriptOutput("3.11.9"))
+
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	if err := os.MkdirAll(filepath.Dir(m.PythonPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakePythonAt(t, m.PythonPath(), probeScriptOutput("3.10.4"))
+
+	recreate, _, err := m.checkVenvPython(context.Background())
+	if err != nil {
+		t.Fatalf("checkVenvPython error = %v", err)
+	}
+	if recreate {
+		t.Fatal("healthy supported venv should not be recreated")
+	}
+}
+
+func TestCheckVenvPythonDetectsStaleVenv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	writeFakePythonAt(t, filepath.Join(dir, "python3.11"), probeScriptOutput("3.11.9"))
+
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	if err := os.MkdirAll(filepath.Dir(m.PythonPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakePythonAt(t, m.PythonPath(), probeScriptOutput("3.9.6"))
+
+	recreate, hostPython, err := m.checkVenvPython(context.Background())
+	if err != nil {
+		t.Fatalf("checkVenvPython error = %v", err)
+	}
+	if !recreate {
+		t.Fatal("3.9 venv should be flagged for recreation")
+	}
+	if hostPython != filepath.Join(dir, "python3.11") {
+		t.Fatalf("hostPython = %q, want %q", hostPython, filepath.Join(dir, "python3.11"))
+	}
+}
+
+func TestEnsureVenvForInstallRecreatesStaleVenv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	hostPython := filepath.Join(dir, "python3.11")
+	writeFakePythonAt(t, hostPython, probeScriptOutput("3.11.9"))
+
+	// The stale venv python must fail the probe so the fresh-venv shortcut
+	// cannot apply; it mimics a 3.9 interpreter that cannot report versions
+	// correctly after its framework was removed.
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	if err := os.MkdirAll(filepath.Dir(m.PythonPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakePythonAt(t, m.PythonPath(), "exit 1\n")
+
+	// The fake host answers the version probe normally, and treats
+	// `-m venv <target>` as creating the venv (touching the directory).
+	// Note: PATH points at the fake dir, so use builtin-safe commands only.
+	venvDir := m.VenvDir()
+	t.Setenv("TEST_VENV_TARGET", venvDir)
+	writeFakePythonAt(t, hostPython, `case "$*" in
+  *-m\ venv*)
+    /bin/rm -rf "$TEST_VENV_TARGET"
+    /bin/mkdir -p "$TEST_VENV_TARGET"
+    exit 0
+    ;;
+esac
+printf '%s\n%s\n' "$0" "3.11.9"
+`)
+
+	progress := func(string, int, int) {}
+	if err := m.ensureVenvForInstall(context.Background(), progress, 1, 1, false); err != nil {
+		t.Fatalf("ensureVenvForInstall error = %v", err)
+	}
+	if _, err := os.Stat(venvDir); err != nil {
+		t.Fatalf("venv directory was not recreated: %v", err)
+	}
+}
+
+func TestEnsureVenvForInstallKeepsHealthyVenvByDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	hostPython := filepath.Join(dir, "python3.13")
+	writeFakePythonAt(t, hostPython, probeScriptOutput("3.13.1"))
+
+	// Healthy 3.11 venv, newer 3.13 host on PATH: the default install
+	// (upgradePackages=false) must not delete the working venv.
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	if err := os.MkdirAll(filepath.Dir(m.PythonPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakePythonAt(t, m.PythonPath(), probeScriptOutput("3.11.9"))
+
+	progress := func(string, int, int) {}
+	if err := m.ensureVenvForInstall(context.Background(), progress, 1, 1, false); err != nil {
+		t.Fatalf("ensureVenvForInstall error = %v", err)
+	}
+	if _, err := os.Stat(m.PythonPath()); err != nil {
+		t.Fatalf("healthy venv should be kept: %v", err)
+	}
+}
+
+func TestEnsureVenvForInstallUpgradesOnExplicitUpgrade(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	hostPython := filepath.Join(dir, "python3.13")
+	writeFakePythonAt(t, hostPython, probeScriptOutput("3.13.1"))
+
+	// Same layout as above, but upgradePackages=true must recreate the venv
+	// so it moves to the newer host interpreter.
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	if err := os.MkdirAll(filepath.Dir(m.PythonPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakePythonAt(t, m.PythonPath(), probeScriptOutput("3.11.9"))
+
+	venvDir := m.VenvDir()
+	t.Setenv("TEST_VENV_TARGET", venvDir)
+	writeFakePythonAt(t, hostPython, `case "$*" in
+  *-m\ venv*)
+    /bin/rm -rf "$TEST_VENV_TARGET"
+    /bin/mkdir -p "$TEST_VENV_TARGET"
+    exit 0
+    ;;
+esac
+printf '%s\n%s\n' "$0" "3.13.1"
+`)
+
+	progress := func(string, int, int) {}
+	if err := m.ensureVenvForInstall(context.Background(), progress, 1, 1, true); err != nil {
+		t.Fatalf("ensureVenvForInstall error = %v", err)
+	}
+	if _, err := os.Stat(venvDir); err != nil {
+		t.Fatalf("venv directory was not recreated: %v", err)
 	}
 }
 


### PR DESCRIPTION
Host interpreter detection only probed python3/python and never checked versions, so macOS machines with the system Python 3.9.6 on PATH built the ASR runtime venv on 3.9, where qwen-asr cannot resolve (accelerate 1.12.0 requires Python>=3.10), and the broken venv was reused forever.

- probe candidates newest-first (python3.14..python3.10, then python3, python) and accept only 3.10-3.14, with a clear error naming the rejected interpreter when nothing qualifies
- fall back to well-known absolute interpreter locations (Homebrew, python.org framework, MacPorts, pyenv shims, ~/.local/bin) when PATH is minimal, as in GUI processes launched by Finder/launchd
- recreate the runtime venv automatically when it is missing, broken, or older than the supported range; upgrade to a newer host Python only on an explicit package upgrade (image, ASR, and embedding install flows)
- support CSGHUB_LITE_HOST_PYTHON to point at a specific interpreter, including on Windows
- add py -3.14 to Windows candidate probing and unify version-range error messages