### PR TITLE
fix(inference): cap global num_ctx at the model's own maximum

### DIFF
--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -41,7 +41,7 @@ csghub-lite serve
 | --- | --- | --- |
 | `CSGHUB_LITE_LLAMA_SERVER` | 自动查找 | 指定 `llama-server` 可执行文件的绝对路径。 |
 | `CSGHUB_LITE_LLAMA_READY_TIMEOUT` | 按模型大小计算 | 等待 `llama-server` 就绪的超时。支持 Go duration（如 `45m`、`90s`）或秒数。自动值为 2 分钟加每 GiB 约 1 分钟，范围 2–45 分钟；无法读取文件时为 20 分钟。 |
-| `CSGHUB_LITE_LLAMA_NUM_CTX` | 模型感知，通常 `8192` 或 `16384` | 默认上下文长度，最小有效值为 `1024`。模型声明至少 16384 时默认最多扩展到 16384。 |
+| `CSGHUB_LITE_LLAMA_NUM_CTX` | 模型感知，通常 `8192` 或 `16384` | 默认上下文长度，最小有效值为 `1024`。模型声明至少 16384 时默认最多扩展到 16384。该值对所有模型生效（含 embedding 模型），并会被模型自身的最大上下文长度截断——llama-server 会一次性按上下文长度预分配 KV cache，超出模型上限只会白白占用内存。 |
 | `CSGHUB_LITE_LLAMA_USE_MODEL_MAX_CTX` | `false` | 未显式设置 `num_ctx` 时，使用模型元数据声明的最大上下文。可能显著增加内存占用。 |
 | `CSGHUB_LITE_LLAMA_NUM_PARALLEL` | `1` | 单个 `llama-server` 的并行槽位数，不是同时加载的模型数量。实际 `--ctx-size` 为每槽上下文乘以该值。 |
 | `CSGHUB_LITE_LLAMA_EMBEDDING_POOLING` | 按模型族选择 | 强制 embedding pooling，例如 `last`、`cls` 或 `mean`。Qwen3 Embedding 默认 `last`。 |

--- a/internal/inference/llama.go
+++ b/internal/inference/llama.go
@@ -236,8 +236,9 @@ func llamaReadyTimeout(modelPath string) time.Duration {
 }
 
 // ResolveNumCtx returns the effective llama-server context window (--ctx-size / -c).
-// Explicit requests win, then CSGHUB_LITE_LLAMA_NUM_CTX, then the optional
-// model maximum, then a conservative model-aware fallback.
+// Explicit requests win, then CSGHUB_LITE_LLAMA_NUM_CTX capped at the model
+// maximum, then the optional model maximum, then a conservative model-aware
+// fallback.
 func ResolveNumCtx(modelDir string, requested int) int {
 	return ResolveNumCtxWithModelMax(modelDir, requested, false)
 }
@@ -251,7 +252,12 @@ func ResolveNumCtxWithModelMax(modelDir string, requested int, configured bool) 
 	}
 	if v := strings.TrimSpace(os.Getenv("CSGHUB_LITE_LLAMA_NUM_CTX")); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 1024 {
-			return n
+			// CSGHUB_LITE_LLAMA_NUM_CTX is a global setting that applies to
+			// every model, embedding models included. llama-server allocates a
+			// KV cache for the whole context up front, so a value beyond what
+			// the model itself supports buys nothing and costs memory linearly:
+			// a 0.6B embedding model asked for 128K reserves tens of GB.
+			return capNumCtxToModelMax(modelDir, n)
 		}
 	}
 
@@ -264,6 +270,17 @@ func ResolveNumCtxWithModelMax(modelDir string, requested int, configured bool) 
 	}
 
 	return defaultLlamaCtxSize
+}
+
+// capNumCtxToModelMax limits numCtx to the model's own maximum context length.
+// The model maximum is unknown for some models (it reports 0), and in that case
+// numCtx is kept as requested rather than guessed down.
+func capNumCtxToModelMax(modelDir string, numCtx int) int {
+	maxPos := ModelMaxPositionEmbeddings(modelDir)
+	if maxPos >= 1024 && numCtx > maxPos {
+		return maxPos
+	}
+	return numCtx
 }
 
 // UseModelMaxCtxByDefault returns the effective model-maximum default.

--- a/internal/inference/llama_ctx_test.go
+++ b/internal/inference/llama_ctx_test.go
@@ -37,6 +37,42 @@ func TestResolveNumCtxUsesEnvOverrideBeforeModelMax(t *testing.T) {
 	}
 }
 
+func TestResolveNumCtxCapsEnvOverrideAtModelMax(t *testing.T) {
+	dir := t.TempDir()
+	// Qwen3-Embedding-0.6B tops out at 32768; a global 128K override must not
+	// make llama-server reserve a KV cache four times larger than the model
+	// can ever use.
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"max_position_embeddings":32768}`), 0o644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	t.Setenv("CSGHUB_LITE_LLAMA_NUM_CTX", "131072")
+
+	if got := ResolveNumCtx(dir, 0); got != 32768 {
+		t.Fatalf("ResolveNumCtx returned %d, want %d", got, 32768)
+	}
+}
+
+func TestResolveNumCtxCapsEnvOverrideAtGGUFModelMax(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeMinimalGGUFContextLength(filepath.Join(dir, "model.gguf"), 32768); err != nil {
+		t.Fatalf("write gguf: %v", err)
+	}
+	t.Setenv("CSGHUB_LITE_LLAMA_NUM_CTX", "131072")
+
+	if got := ResolveNumCtx(dir, 0); got != 32768 {
+		t.Fatalf("ResolveNumCtx returned %d, want %d", got, 32768)
+	}
+}
+
+func TestResolveNumCtxKeepsEnvOverrideWhenModelMaxUnknown(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CSGHUB_LITE_LLAMA_NUM_CTX", "131072")
+
+	if got := ResolveNumCtx(dir, 0); got != 131072 {
+		t.Fatalf("ResolveNumCtx returned %d, want %d", got, 131072)
+	}
+}
+
 func TestResolveNumCtxUsesModelMaxWhenEnabled(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"max_position_embeddings":40960}`), 0o644); err != nil {


### PR DESCRIPTION
## Problem

`CSGHUB_LITE_LLAMA_NUM_CTX` is a global setting, and `ResolveNumCtxWithModelMax`
returned it before it ever looked at `ModelMaxPositionEmbeddings`, so the
override could exceed what the model actually supports.

That is expensive rather than merely useless. llama-server reserves a KV cache
for the whole context at startup, and `newLlamaEngineWithMode` passes
`num_ctx * num_parallel` as `-c`. It is also the single path shared by chat and
embedding engines — `newLlamaEmbeddingEngine` only sets `embedding=true` — so an
embedding model inherits a chat-oriented context override.

Observed on a user's host with `CSGHUB_LITE_LLAMA_NUM_CTX=131072` and
`num_parallel=4`:

```
LLAMA: starting llama-server model="Qwen/Qwen3-Embedding-0.6B" embedding=true num_ctx=131072 num_parallel=4
```

Qwen3-Embedding-0.6B tops out at 32768, but llama-server was started with
`-c 524288` (llama-server.log confirms `n_ctx_slot = 131072`, `n_slots = 4`).
Its KV cache is 2 x 28 layers x 8 KV heads x 128 head_dim x 2 bytes = 112 KiB
per token, so that reserves ~56 GiB for a model whose weights are ~1.2 GB.

## Fix

Cap the environment override at `ModelMaxPositionEmbeddings` for embedding and
generation models alike. That helper already reads `max_position_embeddings`
from `config.json` and falls back to the GGUF `.context_length` metadata.

Two deliberate boundaries:

- A model that does not report a maximum (it reads 0) keeps the requested value
  rather than being guessed down.
- An explicit per-request `num_ctx` is still honoured first, as the escape
  hatch. Only the global setting is capped.

With the same configuration, the embedding model now starts at `-c 131072`
(32768 x 4 slots) and its KV cache drops from ~56 GiB to ~14 GiB.

## Tests

Three new cases in `internal/inference/llama_ctx_test.go`:

| Test | Scenario |
|------|----------|
| `TestResolveNumCtxCapsEnvOverrideAtModelMax` | `config.json` says 32768, env asks 131072 -> 32768 |
| `TestResolveNumCtxCapsEnvOverrideAtGGUFModelMax` | no `config.json`, GGUF metadata says 32768 -> 32768 |
| `TestResolveNumCtxKeepsEnvOverrideWhenModelMaxUnknown` | maximum unknown -> 131072 kept |

`go build ./...` passes; `internal/inference` and `internal/server` tests pass.
The existing `TestResolveNumCtxUsesEnvOverrideBeforeModelMax` (env 24576 under a
40960 maximum) is unaffected.

`docs/guides/environment-variables.md` records that the variable applies to
every model including embedding models, that it is capped at the model maximum,
and why.
