### PR TITLE
fix(asr): detect stale Python venv and trigger rebuild on ASR model start

### DIFF
--- a/internal/imagegen/runtime.go
+++ b/internal/imagegen/runtime.go
@@ -414,6 +414,17 @@ func (m *RuntimeManager) ASRStatus(ctx context.Context) RuntimeStatus {
 		status.MissingPackages = append([]string{"torch", "torchaudio"}, requiredASRPythonPackages...)
 		return status
 	}
+	venvVersion, probeErr := probePythonVersionAt(ctx, status.Python)
+	if probeErr != nil {
+		status.Error = fmt.Sprintf("runtime venv python %s is not runnable: %v", status.Python, probeErr)
+		status.MissingPackages = append([]string{"torch", "torchaudio"}, requiredASRPythonPackages...)
+		return status
+	}
+	if !hostPythonSupported(venvVersion) {
+		status.Error = fmt.Sprintf("runtime venv uses Python %s; %s is required", venvVersion, pythonVersionRangeHint)
+		status.MissingPackages = append([]string{"torch", "torchaudio"}, requiredASRPythonPackages...)
+		return status
+	}
 	missing, err := missingPackages(ctx, status.Python, append([]string{"torch", "torchaudio"}, requiredASRPythonPackages...))
 	if err != nil {
 		status.Error = err.Error()
@@ -788,6 +799,9 @@ func embeddingInstallPackagesForMissing(missing []string) []string {
 }
 
 func (m *RuntimeManager) EnsureQwenASRReady(ctx context.Context) error {
+	if venvVersion, err := probePythonVersionAt(ctx, m.PythonPath()); err == nil && !hostPythonSupported(venvVersion) {
+		return fmt.Errorf("runtime venv uses Python %s; %s is required, please reinstall the ASR runtime", venvVersion, pythonVersionRangeHint)
+	}
 	missing, err := missingPackages(ctx, m.PythonPath(), requiredQwenASRPythonPackages)
 	if err != nil {
 		return err

--- a/internal/imagegen/runtime_test.go
+++ b/internal/imagegen/runtime_test.go
@@ -657,6 +657,35 @@ func TestCheckVenvPythonDetectsStaleVenv(t *testing.T) {
 	}
 }
 
+func TestASRStatusDetectsStaleVenvVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh fake pythons")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	writeFakePythonAt(t, filepath.Join(dir, "python3.13"), probeScriptOutput("3.13.1"))
+
+	m := NewRuntimeManagerAt(filepath.Join(dir, "asr-runtime"))
+	if err := os.MkdirAll(filepath.Dir(m.PythonPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakePythonAt(t, m.PythonPath(), probeScriptOutput("3.9.6"))
+
+	status := m.ASRStatus(context.Background())
+	if status.Ready {
+		t.Fatal("stale 3.9.6 venv should not be ready")
+	}
+	if status.Error == "" {
+		t.Fatal("stale venv should produce an error message")
+	}
+	if !strings.Contains(status.Error, "3.9.6") {
+		t.Fatalf("status.Error = %q, want mention of 3.9.6", status.Error)
+	}
+	if !strings.Contains(status.Error, pythonVersionRangeHint) {
+		t.Fatalf("status.Error = %q, want mention of %s", status.Error, pythonVersionRangeHint)
+	}
+}
+
 func TestEnsureVenvForInstallRecreatesStaleVenv(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses sh fake pythons")


### PR DESCRIPTION

ASRStatus only checked whether the venv python binary existed and packages were importable, but never checked the venv's Python version. A venv created with Python 3.9 (e.g. macOS system Python) that already had base ASR packages installed would report Ready=true, skipping the full install flow that would have detected and rebuilt the stale venv. The stale venv then survived to EnsureQwenASRReady, where uv pip install qwen-asr failed because accelerate requires Python>=3.10.

Add a probePythonVersionAt check in ASRStatus that reports not-ready when the venv Python is outside the supported 3.10-3.14 range, triggering the full install flow (ensureVenvForInstall -> checkVenvPython -> rebuild). Add a defense-in-depth version guard in EnsureQwenASRReady that returns a clear error instead of letting uv produce a confusing dependency failure.