### PR TITLE
fix(evaluation): add 5s backoff and 2x timeout on judge retries

### DIFF
--- a/internal/server/provider_pool_evaluation.go
+++ b/internal/server/provider_pool_evaluation.go
@@ -27,7 +27,10 @@ const (
 	providerPoolJudgeMaxTokens             = 2048
 	providerPoolJudgeMaxAttempts           = 3
 	providerPoolJudgeContextBytes          = 32 << 10
+	providerPoolJudgeTimeoutMultiplier     = 2
 )
+
+var providerPoolJudgeRetryBackoff = 5 * time.Second
 
 type ProviderPoolEvaluationRequest struct {
 	PoolID                string
@@ -564,7 +567,11 @@ func (s *Server) runProviderPoolEvaluation(ctx context.Context, job routerprofil
 				fail(err)
 				return
 			}
-			callCtx, cancel := context.WithTimeout(ctx, time.Duration(job.RequestTimeoutSeconds)*time.Second)
+			timeoutSeconds := job.RequestTimeoutSeconds
+			if cell.JudgeAttemptCount > 1 {
+				timeoutSeconds *= providerPoolJudgeTimeoutMultiplier
+			}
+			callCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 			judged, judgeErr := s.evaluationChatCompletion(callCtx, job.JudgeModel, "cloud",
 				[]routerprofile.Message{{Role: "user", Content: judgePrompt}}, providerPoolJudgeMaxTokens, true)
 			cancel()
@@ -618,6 +625,12 @@ func (s *Server) runProviderPoolEvaluation(ctx context.Context, job routerprofil
 			}
 			if !providerPoolJudgeRetryable(lastJudgeErr) {
 				break
+			}
+			select {
+			case <-ctx.Done():
+				fail(ctx.Err())
+				return
+			case <-time.After(providerPoolJudgeRetryBackoff):
 			}
 		}
 		if !judgeSucceeded {
@@ -843,7 +856,11 @@ func (s *Server) runProviderPoolListwiseEvaluation(ctx context.Context, job rout
 				fail(err)
 				return
 			}
-			callCtx, cancel := context.WithTimeout(ctx, time.Duration(job.RequestTimeoutSeconds)*time.Second)
+			timeoutSeconds := job.RequestTimeoutSeconds
+			if round.JudgeAttemptCount > 1 {
+				timeoutSeconds *= providerPoolJudgeTimeoutMultiplier
+			}
+			callCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 			judged, judgeErr := s.evaluationChatCompletion(callCtx, job.JudgeModel, "cloud",
 				[]routerprofile.Message{{Role: "user", Content: judgePrompt}}, providerPoolJudgeMaxTokens, true)
 			cancel()
@@ -893,6 +910,12 @@ func (s *Server) runProviderPoolListwiseEvaluation(ctx context.Context, job rout
 			}
 			if !providerPoolJudgeRetryable(judgeErr) {
 				break
+			}
+			select {
+			case <-ctx.Done():
+				fail(ctx.Err())
+				return
+			case <-time.After(providerPoolJudgeRetryBackoff):
 			}
 		}
 		if lastJudgeErr != nil || round.Status != routerprofile.RoundSucceeded {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -65,6 +65,7 @@ func (e *scriptedChatEngine) Close() error {
 func (e *scriptedChatEngine) ModelName() string { return "scripted" }
 
 func TestMain(m *testing.M) {
+	providerPoolJudgeRetryBackoff = 0
 	_ = os.Setenv(config.DisableFileLoggingEnv, "1")
 	if home, err := os.MkdirTemp("", "csghub-lite-server-test-home-*"); err == nil {
 		_ = os.Setenv("HOME", home)


### PR DESCRIPTION
First judge attempt uses the user-configured request timeout (default 60s). On retry, the timeout doubles (120s) to give the remote API more time after a transient failure. 
Add 5s backoff between judge retries so transient timeouts get a recovery window instead of firing three attempts back-to-back. Set backoff to 0 in tests to avoid slowdown.