### PR TITLE
fix(models): detect codec-token text-to-speech models

### DIFF
--- a/internal/localinference/support.go
+++ b/internal/localinference/support.go
@@ -84,7 +84,7 @@ func FromMarketplaceModel(format, architecture, className, modelName, pipelineTa
 	if model.IsASRModelFamily(modelName) {
 		return asrSupport(architecture)
 	}
-	if model.IsTTSModelFamily(modelName) {
+	if model.IsTTSModelFamily(modelName) || model.IsTTSModelName(modelName) {
 		return unsupported(architecture)
 	}
 	return FromMarketplace(format, architecture, className)

--- a/internal/localinference/support_test.go
+++ b/internal/localinference/support_test.go
@@ -243,3 +243,34 @@ func TestTextToSpeechNeverUsesLlamaConvertPath(t *testing.T) {
 		}
 	})
 }
+
+// The model named in issue #147. Its architecture is convertible, so a missed
+// detection means the GGUF conversion succeeds and the model is served as text.
+func TestCodecTokenTTSModelIsNotConvertible(t *testing.T) {
+	name := "modelscope/Vikhrmodels/Qwen3-0.6B-TTS"
+
+	support := FromMarketplaceModel("safetensors", "Qwen3ForCausalLM", "", name, "")
+	if support.Supported || support.Mode == "convert" {
+		t.Fatalf("marketplace support = %#v, want unsupported", support)
+	}
+
+	dir := t.TempDir()
+	for file, body := range map[string]string{
+		"config.json":        `{"architectures":["Qwen3ForCausalLM"],"model_type":"qwen3","vocab_size":160887}`,
+		"configuration.json": `{"framework":"pytorch","task":"others"}`,
+		"added_tokens.json":  `{"<|start_of_audio|>":151669,"<|end_of_audio|>":151670}`,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lm := &model.LocalModel{Namespace: "Vikhrmodels", Name: "Qwen3-0.6B-TTS", Format: model.FormatSafeTensors}
+	if support := FromLocalModel(lm, dir); support.Supported || support.Mode == "convert" {
+		t.Fatalf("local support = %#v, want unsupported", support)
+	}
+
+	// Regression guard: a plain Qwen3 text model must stay convertible.
+	if support := FromMarketplaceModel("safetensors", "Qwen3ForCausalLM", "", "Qwen/Qwen3-0.6B", ""); !support.Supported || support.Mode != "convert" {
+		t.Fatalf("plain text model support = %#v, want llama convert", support)
+	}
+}

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -121,6 +122,32 @@ var ttsModelFamilies = []string{
 	"Zonos",
 	"Higgs-Audio",
 	"SambertHifigan",
+}
+
+// Codec-token text-to-speech models are indistinguishable from plain text
+// models by config alone: Vikhrmodels/Qwen3-0.6B-TTS declares
+// architectures: ["Qwen3ForCausalLM"] with model_type "qwen3", carries no
+// pipeline tag, and its ModelScope task is "others". What gives it away is the
+// tokenizer -- it has a matched pair of audio span tokens, because it generates
+// audio codec tokens rather than text. A plain text model never has those.
+var audioSpanStartTokens = []string{
+	"<|start_of_audio|>",
+	"<|begin_of_audio|>",
+	"<|start_of_speech|>",
+	"<|begin_of_speech|>",
+}
+
+var audioSpanEndTokens = []string{
+	"<|end_of_audio|>",
+	"<|end_of_speech|>",
+}
+
+// tokenizerFilesWithAddedTokens are small enough to read eagerly. tokenizer.json
+// is deliberately excluded: it routinely runs to tens of megabytes.
+var tokenizerFilesWithAddedTokens = []string{
+	"added_tokens.json",
+	"special_tokens_map.json",
+	"tokenizer_config.json",
 }
 
 var embeddingArchitectures = map[string]bool{
@@ -242,6 +269,51 @@ func IsTTSModelFamily(name string) bool {
 	return false
 }
 
+// HasAudioOutputTokens reports whether the tokenizer in modelDir defines a
+// matched pair of audio span tokens, which marks a model that generates audio
+// codec tokens. Both ends are required: a generator needs to open and close the
+// span, whereas an audio-input model may declare only a leading marker.
+func HasAudioOutputTokens(modelDir string) bool {
+	modelDir = strings.TrimSpace(modelDir)
+	if modelDir == "" {
+		return false
+	}
+	var start, end bool
+	for _, name := range tokenizerFilesWithAddedTokens {
+		data, err := os.ReadFile(filepath.Join(modelDir, name))
+		if err != nil {
+			continue
+		}
+		lowered := strings.ToLower(string(data))
+		for _, token := range audioSpanStartTokens {
+			if strings.Contains(lowered, token) {
+				start = true
+				break
+			}
+		}
+		for _, token := range audioSpanEndTokens {
+			if strings.Contains(lowered, token) {
+				end = true
+				break
+			}
+		}
+		if start && end {
+			return true
+		}
+	}
+	return false
+}
+
+var ttsNamePattern = regexp.MustCompile(`(^|[^a-z0-9])tts([^a-z0-9]|$)`)
+
+// IsTTSModelName reports whether a model id or name marks itself as
+// text-to-speech with a delimited "tts" token, such as Qwen3-0.6B-TTS. The
+// family list cannot cover the long tail of fine-tunes that only say so in
+// their name.
+func IsTTSModelName(name string) bool {
+	return ttsNamePattern.MatchString(strings.ToLower(strings.TrimSpace(name)))
+}
+
 // DetectPipelineTag reads config.json in modelDir and returns a local pipeline
 // tag for routing. Sentence-transformers repositories are treated as embedding
 // models even when the hub metadata was not persisted in older manifests.
@@ -253,7 +325,7 @@ func DetectPipelineTag(modelDir string) string {
 	if IsASRModelFamily(modelDir) {
 		return "automatic-speech-recognition"
 	}
-	if IsTTSModelFamily(modelDir) {
+	if IsTTSModelFamily(modelDir) || IsTTSModelName(modelDir) || HasAudioOutputTokens(modelDir) {
 		return "text-to-speech"
 	}
 	if tag := detectDiffusersPipelineTag(modelDir); tag != "" {

--- a/internal/model/manifest_test.go
+++ b/internal/model/manifest_test.go
@@ -665,3 +665,85 @@ func TestIsTTSModelFamilyDoesNotClaimASRModels(t *testing.T) {
 		}
 	}
 }
+
+// Vikhrmodels/Qwen3-0.6B-TTS is the case that defeats every config-based check:
+// architectures ["Qwen3ForCausalLM"], model_type "qwen3", no pipeline tag in the
+// model card, and a ModelScope task of "others". Only the tokenizer's matched
+// pair of audio span tokens and the "TTS" in its name give it away. Because
+// Qwen3ForCausalLM *is* convertible, missing it means the GGUF conversion
+// succeeds and the model is served as a text model producing garbage.
+func TestDetectPipelineTagCodecTokenTTSModelWithCausalLMConfig(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "Qwen3-0.6B")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("config.json", `{"architectures":["Qwen3ForCausalLM"],"model_type":"qwen3","vocab_size":160887}`)
+	write("configuration.json", `{"framework":"pytorch","task":"others","allow_remote":true}`)
+	write("added_tokens.json", `{"<|start_of_audio|>":151669,"<|end_of_audio|>":151670,"<|im_end|>":151645}`)
+
+	// The directory name here carries no "TTS" marker, so the tokenizer is the
+	// only remaining signal.
+	if !HasAudioOutputTokens(dir) {
+		t.Fatal("HasAudioOutputTokens() = false, want true")
+	}
+	if got := DetectPipelineTag(dir); got != "text-to-speech" {
+		t.Fatalf("DetectPipelineTag() = %q, want text-to-speech", got)
+	}
+}
+
+// A plain text model must keep its text-generation tag: an audio-input model may
+// declare a leading audio marker without being a speech generator, so both ends
+// of the span are required.
+func TestHasAudioOutputTokensRequiresBothSpanEnds(t *testing.T) {
+	cases := map[string]struct {
+		addedTokens string
+		want        bool
+	}{
+		"both ends":      {`{"<|start_of_audio|>":1,"<|end_of_audio|>":2}`, true},
+		"start only":     {`{"<|start_of_audio|>":1}`, false},
+		"end only":       {`{"<|end_of_audio|>":2}`, false},
+		"speech variant": {`{"<|start_of_speech|>":1,"<|end_of_speech|>":2}`, true},
+		"plain text":     {`{"<|im_end|>":151645,"<|endoftext|>":151643}`, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "added_tokens.json"), []byte(tc.addedTokens), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if got := HasAudioOutputTokens(dir); got != tc.want {
+				t.Fatalf("HasAudioOutputTokens() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsTTSModelName(t *testing.T) {
+	for _, name := range []string{
+		"modelscope/Vikhrmodels/Qwen3-0.6B-TTS",
+		"Qwen3-0.6B-TTS",
+		"some/tts-model",
+		"a/b_tts_v2",
+	} {
+		if !IsTTSModelName(name) {
+			t.Errorf("IsTTSModelName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{
+		"",
+		"Qwen/Qwen3-0.6B",
+		"modelscope/Qwen/Qwen3-ASR-0.6B",
+		"iic/SenseVoiceSmall",
+		"some/nottsmodel",
+	} {
+		if IsTTSModelName(name) {
+			t.Errorf("IsTTSModelName(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/modelmetadata/store.go
+++ b/internal/modelmetadata/store.go
@@ -140,10 +140,21 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
+// DerivationVersion invalidates cached derivations when the logic that computes
+// them changes rather than when the model files change. Fingerprint hashes file
+// identity only, so an untouched model directory would otherwise keep a
+// pipeline tag derived by an older build: a text-to-speech model cached as
+// "text-generation" before DetectPipelineTag learned to recognise codec-token
+// TTS models would stay misclassified after an upgrade. Bump this whenever
+// DetectPipelineTag or any other cached derivation changes.
+const DerivationVersion = 2
+
 // Fingerprint hashes file identity metadata without reading model contents.
-// Any add, remove, resize, or modification invalidates the cached derivations.
+// Any add, remove, resize, or modification invalidates the cached derivations,
+// as does a DerivationVersion bump.
 func Fingerprint(modelDir string) (string, error) {
 	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "derivation-version\x00%d\n", DerivationVersion)
 	err := filepath.WalkDir(modelDir, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr

--- a/internal/modelmetadata/store_test.go
+++ b/internal/modelmetadata/store_test.go
@@ -2,6 +2,9 @@ package modelmetadata
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,5 +76,37 @@ func TestStoreMissesWhenFingerprintChanges(t *testing.T) {
 	}
 	if _, ok, err := store.Get(context.Background(), "acme/demo", "new"); err != nil || ok {
 		t.Fatalf("Get() changed fingerprint = ok %v, err %v", ok, err)
+	}
+}
+
+// A change in derivation logic must invalidate cached entries even though the
+// model files are untouched, otherwise an upgraded build keeps serving a
+// pipeline tag computed by the previous one. The digest is therefore seeded
+// with DerivationVersion rather than being a pure file-identity hash.
+func TestFingerprintIsSeededWithDerivationVersion(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Fingerprint(dir)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unseeded := sha256.New()
+	fmt.Fprintf(unseeded, "%s\x00%d\x00%d\x00%d\n", "config.json", info.Size(), info.ModTime().UnixNano(), info.Mode())
+	if got == hex.EncodeToString(unseeded.Sum(nil)) {
+		t.Fatal("Fingerprint() is a pure file-identity hash; a derivation-logic change would not invalidate the cache")
+	}
+
+	seeded := sha256.New()
+	fmt.Fprintf(seeded, "derivation-version\x00%d\n", DerivationVersion)
+	fmt.Fprintf(seeded, "%s\x00%d\x00%d\x00%d\n", "config.json", info.Size(), info.ModTime().UnixNano(), info.Mode())
+	if got != hex.EncodeToString(seeded.Sum(nil)) {
+		t.Fatalf("Fingerprint() = %q, want the DerivationVersion-seeded digest", got)
 	}
 }

--- a/internal/server/handlers_marketplace.go
+++ b/internal/server/handlers_marketplace.go
@@ -789,6 +789,8 @@ func marketplaceInferredTaskTag(details *csghub.Model, architecture string, supp
 	switch {
 	case model.IsASRModelFamily(haystack):
 		return "automatic-speech-recognition"
+	case model.IsTTSModelFamily(haystack) || model.IsTTSModelName(haystack):
+		return "text-to-speech"
 	case strings.Contains(haystack, "whisper") ||
 		strings.Contains(haystack, "wav2vec") ||
 		strings.Contains(haystack, "speech-recognition") ||
@@ -812,6 +814,8 @@ func marketplaceTaskShowName(task string) string {
 		return "Sentence Similarity"
 	case "automatic-speech-recognition":
 		return "Automatic Speech Recognition"
+	case "text-to-speech":
+		return "Text to Speech"
 	default:
 		return task
 	}


### PR DESCRIPTION
The text-to-speech routing shipped in v0.9.70 missed the model class #147 is
actually about. Refs #147.

## The gap

`modelscope/Vikhrmodels/Qwen3-0.6B-TTS`, the model named in the latest feedback,
defeats every check added in v0.9.70:

| Signal | Value | Caught? |
| --- | --- | --- |
| `config.json` architectures | `["Qwen3ForCausalLM"]` | no |
| `config.json` model_type | `qwen3` | no |
| `configuration.json` task | `others` | no |
| model card `pipeline_tag` | absent | no |
| family name list | no match on `Qwen3-0.6B-TTS` | no |

Measured before this change:

```
DetectPipelineTag    = "text-generation"
FromLocalModel       = {Supported:true, Runtime:"llama", Mode:"convert",
                        Architecture:"Qwen3ForCausalLM", RuntimeArchitecture:"qwen3"}
```

Unlike Kokoro — which fails conversion because its architecture is unrecognised —
`Qwen3ForCausalLM` **is** convertible, so the GGUF conversion succeeds and the
model is served as a text model, emitting garbage instead of audio. That is the
original complaint in #147, still live.

## The fix

Two architecture-independent signals:

1. **A matched pair of audio span tokens in the tokenizer** — e.g.
   `<|start_of_audio|>` together with `<|end_of_audio|>`. A model that opens and
   closes an audio span generates audio codec tokens; a plain text model has no
   such tokens. Both ends are required, so an audio-*input* model that declares
   only a leading marker is not misclassified.
2. **A delimited `tts` token in the model id** — the family list cannot cover the
   long tail of fine-tunes that only say so in their name.

After:

```
DetectPipelineTag      = "text-to-speech"
HasAudioOutputTokens   = true
FromLocalModel         = {Supported:false, Mode:"none"}
plain Qwen/Qwen3-0.6B  = {Supported:true, Runtime:"llama", Mode:"convert"}   <- unchanged
IsTTSModelName("Qwen3-ASR-0.6B") = false
```

Regression tests cover the missed model, both-ends-required token detection, the
plain text model staying convertible, and ASR names being unaffected.
`go test ./...` → 34 packages ok.

Generated with AI

Co-Authored-By: csglite <xzhgan@gmail.com>
