### PR TITLE
fix(chat): show the voice picker without reselecting the model

### DIFF
--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1017,9 +1017,21 @@ export function Chat() {
   // Load the voices of the selected text-to-speech model. Listing them loads the
   // model in the runtime, so it runs only for a text-to-speech selection and
   // only once per model.
+  //
+  // ttsVoicesModel guards against repeating the request, and it has to be
+  // cleared on every path that leaves the list unpopulated. Leaving it set after
+  // a failure -- likely on a fresh page load, where the request races the
+  // runtime coming up -- made the effect early-return forever, so the voice
+  // picker stayed empty until the model was reselected.
   useEffect(() => {
     const model = selectedModelInfo.value;
-    if (!model || getChatModelMode(model) !== "tts") {
+    // The model list loads asynchronously, so "nothing selected yet" is not the
+    // same as "a non-speech model is selected"; clearing on the former would
+    // discard a list already loaded before navigating away.
+    if (!model) {
+      return;
+    }
+    if (getChatModelMode(model) !== "tts") {
       if (ttsVoices.value.length > 0) ttsVoices.value = [];
       ttsVoicesModel.value = "";
       selectedVoice.value = "";
@@ -1031,7 +1043,10 @@ export function Chat() {
     ttsVoicesModel.value = key;
     getTTSVoices(key)
       .then((resp) => {
-        if (cancelled) return;
+        if (cancelled) {
+          ttsVoicesModel.value = "";
+          return;
+        }
         const voices = resp.voices || [];
         ttsVoices.value = voices;
         if (!voices.some((v) => v.id === selectedVoice.value)) {
@@ -1039,9 +1054,11 @@ export function Chat() {
         }
       })
       .catch(() => {
+        // Allow a retry: a model whose voices cannot be listed still synthesises
+        // with its default voice, so this is not surfaced as an error, but the
+        // next run must be free to ask again.
+        ttsVoicesModel.value = "";
         if (cancelled) return;
-        // A model whose voices cannot be listed still synthesises with its
-        // default voice, so this is not surfaced as an error.
         ttsVoices.value = [];
         selectedVoice.value = "";
       });


### PR DESCRIPTION
Entering chat with a text-to-speech model already selected often left the voice
picker empty until the model was reselected. Two defects in the effect that
loads the voices, both introduced with the picker in #165.

## The de-duplication guard was never cleared on failure

`ttsVoicesModel` is set to the model key *before* the request, to stop the
effect asking twice. The `.catch` did not clear it, so a single failed attempt
disabled the effect permanently for that model.

That first attempt is likely to fail: listing voices loads the model in the
runtime, so on a fresh page load it races the runtime coming up. Reselecting the
model changed the key and slipped past the stale guard — which is exactly why it
looked as though reselecting was required.

The guard is now cleared on every path that leaves the list unpopulated, so a
later run can ask again.

## A not-yet-resolved model cleared the state

The effect cleared the voices whenever `selectedModelInfo` yielded no model. It
is a computed over `availableModels`, which loads asynchronously, so that is the
normal state on the first render — and the signals holding the picker's state are
module level, outliving navigation. Returning to chat therefore discarded a list
that had already loaded.

"Nothing selected yet" is now distinguished from "a non-speech model is
selected", and only the latter clears.

## Checks

`tsc --noEmit` clean, 54 frontend tests pass, `go test ./...` 35 packages ok.

Verified by hand against a local deployment: selecting a speech model, navigating
away and back, and reloading the page all leave the picker populated without
reselecting.

Generated with AI

Co-Authored-By: csglite <xzhgan@gmail.com>
