### PR TITLE
fix(web): send the model id, not the dropdown key, from realtime voice

### DIFF
--- a/web/src/components/RealtimeVoiceDialog.tsx
+++ b/web/src/components/RealtimeVoiceDialog.tsx
@@ -3,8 +3,17 @@ import { endRealtimeCall, getTTSVoices, startRealtimeCall, type SpeechVoice } fr
 import { t } from "../i18n";
 
 export interface RealtimeVoiceModel {
+  // key identifies the option in the dropdown; it is unique across sources.
   key: string;
+  // id is what the server knows the model as, which is not the same string.
+  id: string;
   label: string;
+}
+
+// realtimeModelID resolves a selected option back to the id the API expects.
+export function realtimeModelID(models: RealtimeVoiceModel[], key: string): string {
+  if (!key) return "";
+  return models.find((m) => m.key === key)?.id || "";
 }
 
 type CallState = "idle" | "connecting" | "live" | "ended";
@@ -49,6 +58,8 @@ export function RealtimeVoiceDialog({
 }) {
   const [asrModel, setASRModel] = useState(initialASRModel || asrModels[0]?.key || "");
   const [ttsModel, setTTSModel] = useState(initialTTSModel || ttsModels[0]?.key || "");
+  const asrModelID = realtimeModelID(asrModels, asrModel);
+  const ttsModelID = realtimeModelID(ttsModels, ttsModel);
   const [voices, setVoices] = useState<SpeechVoice[]>([]);
   const [voice, setVoice] = useState("");
   const [state, setState] = useState<CallState>("idle");
@@ -67,13 +78,13 @@ export function RealtimeVoiceDialog({
   // Voices are listed per model, and listing them loads the model, so this runs
   // only when a synthesis model is actually selected.
   useEffect(() => {
-    if (!ttsModel) {
+    if (!ttsModelID) {
       setVoices([]);
       setVoice("");
       return;
     }
     let cancelled = false;
-    getTTSVoices(ttsModel)
+    getTTSVoices(ttsModelID)
       .then((resp) => {
         if (cancelled) return;
         const list = resp.voices || [];
@@ -87,7 +98,7 @@ export function RealtimeVoiceDialog({
         setVoice("");
       });
     return () => { cancelled = true; };
-  }, [ttsModel]);
+  }, [ttsModelID]);
 
   const appendLine = (text: string, final: boolean) => {
     setLines((prev) => {
@@ -205,8 +216,8 @@ export function RealtimeVoiceDialog({
       });
 
       const call = await startRealtimeCall(peer.localDescription?.sdp || offer.sdp || "", {
-        asrModel: asrModel || undefined,
-        ttsModel: ttsModel || undefined,
+        asrModel: asrModelID || undefined,
+        ttsModel: ttsModelID || undefined,
         voice: voice || undefined,
       });
       callIdRef.current = call.callId;

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -20,6 +20,7 @@ import {
   formatModelOptionLabel as modelLabel,
   loadModelOptions,
   modelOptionKey as modelKey,
+  realtimeVoiceOptions as buildRealtimeVoiceOptions,
 } from "../utils/modelOptions";
 
 const availableModels = signal<ModelInfo[]>([]);
@@ -1701,6 +1702,9 @@ export function Chat() {
     saveCurrentConversation();
   };
 
+  const realtimeVoiceOptions = (matches: (model: ModelInfo) => boolean) =>
+    buildRealtimeVoiceOptions(availableModels.value, matches, modelLabel);
+
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -2203,8 +2207,8 @@ export function Chat() {
       )}
       {showRealtimeVoice.value && (
         <RealtimeVoiceDialog
-          asrModels={availableModels.value.filter(isASRModel).map((m) => ({ key: modelKey(m), label: modelLabel(m) }))}
-          ttsModels={availableModels.value.filter(isTTSModel).map((m) => ({ key: modelKey(m), label: modelLabel(m) }))}
+          asrModels={realtimeVoiceOptions(isASRModel)}
+          ttsModels={realtimeVoiceOptions(isTTSModel)}
           initialASRModel={asrMode ? modelKey(selectedModelInfo.value!) : undefined}
           initialTTSModel={ttsMode ? modelKey(selectedModelInfo.value!) : undefined}
           onClose={() => { showRealtimeVoice.value = false; }}

--- a/web/src/realtimeModelID.test.ts
+++ b/web/src/realtimeModelID.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The module graph reaches i18n, which reads the saved locale on import.
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: { getItem: () => null, setItem: () => undefined },
+  });
+});
+
+import { realtimeModelID, type RealtimeVoiceModel } from "./components/RealtimeVoiceDialog";
+import { modelOptionID, modelOptionKey, realtimeVoiceOptions } from "./utils/modelOptions";
+
+// The dropdown key and the model id are different strings. Sending the key as
+// a model id asked the server for "local:Fun-ASR-Nano-2512", which it reported
+// as not downloaded even though the model was there.
+describe("realtime model identifiers", () => {
+  it("keeps the option key separate from the id the server knows", () => {
+    const model = { model: "Fun-ASR-Nano-2512", name: "Fun-ASR-Nano-2512", source: "local" };
+    expect(modelOptionKey(model)).toBe("local:Fun-ASR-Nano-2512");
+    expect(modelOptionID(model)).toBe("Fun-ASR-Nano-2512");
+  });
+
+  it("resolves a selected option to the model id", () => {
+    const models: RealtimeVoiceModel[] = [
+      { key: "local:Fun-ASR-Nano-2512", id: "Fun-ASR-Nano-2512", label: "Fun-ASR-Nano-2512" },
+      { key: "local:modelscope/iic/SenseVoiceSmall", id: "modelscope/iic/SenseVoiceSmall", label: "SenseVoiceSmall" },
+    ];
+    expect(realtimeModelID(models, "local:Fun-ASR-Nano-2512")).toBe("Fun-ASR-Nano-2512");
+    expect(realtimeModelID(models, "local:modelscope/iic/SenseVoiceSmall")).toBe("modelscope/iic/SenseVoiceSmall");
+  });
+
+  // Nothing selected, and an option that has gone away, both mean "no model"
+  // rather than a model id that happens to look like a key.
+  it("reports no model for an empty or unknown selection", () => {
+    const models: RealtimeVoiceModel[] = [{ key: "local:a", id: "a", label: "a" }];
+    expect(realtimeModelID(models, "")).toBe("");
+    expect(realtimeModelID(models, "local:gone")).toBe("");
+    expect(realtimeModelID([], "local:a")).toBe("");
+  });
+
+  // A model id can itself contain a colon (a GGUF quant suffix), so the id
+  // cannot be recovered by splitting the key.
+  it("survives a model id that contains a colon", () => {
+    const model = { model: "Qwen/Qwen-Image-2512:s-qwen-image-6byf", source: "local" };
+    const models: RealtimeVoiceModel[] = [
+      { key: modelOptionKey(model), id: modelOptionID(model), label: "x" },
+    ];
+    expect(realtimeModelID(models, modelOptionKey(model))).toBe("Qwen/Qwen-Image-2512:s-qwen-image-6byf");
+  });
+});
+
+describe("realtime voice options", () => {
+  const label = (m: { model?: string; name?: string }) => m.model || m.name || "";
+  const isASR = (m: { pipeline_tag?: string }) => m.pipeline_tag === "automatic-speech-recognition";
+
+  it("offers local models with both identifiers", () => {
+    const models = [
+      { model: "Fun-ASR-Nano-2512", pipeline_tag: "automatic-speech-recognition", source: "local" },
+      { model: "modelscope/iic/SenseVoiceSmall", pipeline_tag: "automatic-speech-recognition" },
+    ] as any[];
+    expect(realtimeVoiceOptions(models, isASR, label)).toEqual([
+      { key: "local:Fun-ASR-Nano-2512", id: "Fun-ASR-Nano-2512", label: "Fun-ASR-Nano-2512" },
+      {
+        key: "local:modelscope/iic/SenseVoiceSmall",
+        id: "modelscope/iic/SenseVoiceSmall",
+        label: "modelscope/iic/SenseVoiceSmall",
+      },
+    ]);
+  });
+
+  // The call runs on the local Python runtimes, so a cloud or provider model
+  // could only fail once the user pressed start.
+  it("leaves out models this runtime cannot serve", () => {
+    const models = [
+      { model: "cloud/asr", pipeline_tag: "automatic-speech-recognition", source: "cloud" },
+      { model: "pool/asr", pipeline_tag: "automatic-speech-recognition", source: "provider" },
+      { model: "local/asr", pipeline_tag: "automatic-speech-recognition", source: "local" },
+      { model: "local/chat", pipeline_tag: "text-generation", source: "local" },
+      { model: "", pipeline_tag: "automatic-speech-recognition", source: "local" },
+    ] as any[];
+    expect(realtimeVoiceOptions(models, isASR, label).map((o) => o.id)).toEqual(["local/asr"]);
+  });
+});

--- a/web/src/utils/modelOptions.ts
+++ b/web/src/utils/modelOptions.ts
@@ -5,6 +5,29 @@ export function modelOptionKey(model: { model?: string; name?: string; source?: 
   return `${model.source || "local"}:${model.model || model.name}`;
 }
 
+// modelOptionID is what the API calls the model. It is deliberately not
+// modelOptionKey: that one prefixes the source to keep the dropdown's options
+// unique, and sending it as a model id asks the server for a model that does
+// not exist ("local:Fun-ASR-Nano-2512").
+export function modelOptionID(model: { model?: string; name?: string }): string {
+  return (model.model || model.name || "").trim();
+}
+
+// realtimeVoiceOptions builds the dropdown entries for the realtime voice
+// dialog. Only local models are offered, because the call is served by the
+// local Python runtimes and a cloud or provider model would fail on connect.
+// Each entry carries both identifiers: the key keeps the option unique in the
+// dropdown, the id is what the server is asked for.
+export function realtimeVoiceOptions(
+  models: ModelInfo[],
+  matches: (model: ModelInfo) => boolean,
+  label: (model: ModelInfo) => string,
+): { key: string; id: string; label: string }[] {
+  return models
+    .filter((model) => matches(model) && (!model.source || model.source === "local") && modelOptionID(model) !== "")
+    .map((model) => ({ key: modelOptionKey(model), id: modelOptionID(model), label: label(model) }));
+}
+
 export function normalizeModelOptions(models: ModelInfo[]): ModelInfo[] {
   const seen = new Set<string>();
   const out: ModelInfo[] = [];


### PR DESCRIPTION
Reported from a log: starting a realtime call reported

```
REALTIME: transcription unavailable: model "local:Fun-ASR-Nano-2512" not found locally; use 'csghub-lite pull local:Fun-ASR-Nano-2512' first
```

for a model that was downloaded. The dialog passed `modelOptionKey` — ```${source}:${id}``` — where the server wanted the model id. The key exists to keep the dropdown unique across sources; it is not an identifier the API knows.

Options now carry both identifiers. They cannot be derived from one another: a model id may contain a colon of its own (`Qwen/Qwen-Image-2512:s-qwen-image-6byf`), so splitting the key would corrupt those ids. `modelOptionID` is now the single place that says what the API calls a model, next to `modelOptionKey`.

The dialog also lists only local models. The call is served by the local Python runtimes, so a cloud or provider model was an option that could only fail after the user pressed start.

Tests cover the two identifiers staying distinct, resolving a selection back to an id, an id containing a colon, and the option list dropping cloud, provider and text models.

Generated with AI

Co-Authored-By: csglite <xzhgan@gmail.com>